### PR TITLE
✨ Add settings panel with persistence and custom API credentials

### DIFF
--- a/Requirements/README.md
+++ b/Requirements/README.md
@@ -13,7 +13,9 @@ Requirements/
 │   ├── SYSREQ-003-authentication.md
 │   ├── SYSREQ-004-auto-refresh.md
 │   ├── SYSREQ-005-manual-refresh.md
-│   └── SYSREQ-006-error-handling.md
+│   ├── SYSREQ-006-error-handling.md
+│   ├── SYSREQ-007-flight-trails.md
+│   └── SYSREQ-008-settings-panel.md
 ├── ui/                             ← User interface requirements (UIREQ-*)
 │   ├── UIREQ-001-flight-list-view.md
 │   ├── UIREQ-002-flight-map-view.md
@@ -84,6 +86,7 @@ Scenarios are structured for future automated UI test generation. Each scenario 
 | [SYSREQ-005](core/SYSREQ-005-manual-refresh.md) | Manual Refresh | medium | implemented |
 | [SYSREQ-006](core/SYSREQ-006-error-handling.md) | Error Handling | medium | implemented |
 | [SYSREQ-007](core/SYSREQ-007-flight-trails.md) | Flight Trails | medium | implemented |
+| [SYSREQ-008](core/SYSREQ-008-settings-panel.md) | Settings Panel | high | implemented |
 
 ### User Interface Requirements (UIREQ-*)
 

--- a/Requirements/core/SYSREQ-008-settings-panel.md
+++ b/Requirements/core/SYSREQ-008-settings-panel.md
@@ -1,0 +1,228 @@
+---
+id: SYSREQ-008
+title: Settings Panel
+priority: high
+type: feature
+status: implemented
+tags: [settings, persistence, configuration, user-preferences, units]
+scenarios:
+  - id: SC-SYSREQ-008-01
+    name: Open settings panel
+    given: The app is running
+    when: User taps the gear icon in the toolbar
+    then: The settings sheet is presented with all configuration sections
+  - id: SC-SYSREQ-008-02
+    name: Change search radius
+    given: The settings panel is open
+    when: User selects a different search radius option
+    then: The new radius is persisted and used for subsequent flight fetches
+  - id: SC-SYSREQ-008-03
+    name: Change refresh interval to manual
+    given: Auto-refresh is active with a preset interval
+    when: User selects "Manual" in the refresh options
+    then: Auto-refresh is disabled and only manual refreshes are possible
+  - id: SC-SYSREQ-008-04
+    name: Set custom refresh interval
+    given: The settings panel is open
+    when: User selects "Custom" and enters a number of seconds
+    then: Auto-refresh uses the custom interval
+  - id: SC-SYSREQ-008-05
+    name: Change map style
+    given: The settings panel is open
+    when: User selects a different map style
+    then: The map view immediately applies the new style
+  - id: SC-SYSREQ-008-06
+    name: Configure custom API credentials
+    given: The settings panel is open
+    when: User enters a Client ID and Client Secret
+    then: The credentials are persisted and used for authentication, overriding environment variables
+  - id: SC-SYSREQ-008-07
+    name: Settings persist across app restarts
+    given: User has changed one or more settings
+    when: The app is closed and reopened
+    then: All previously saved settings are restored
+  - id: SC-SYSREQ-008-08
+    name: Clear custom API credentials
+    given: Custom API credentials are configured
+    when: User taps "Clear Credentials"
+    then: Both Client ID and Client Secret are cleared and the app falls back to environment variables
+  - id: SC-SYSREQ-008-09
+    name: Change altitude unit
+    given: The settings panel is open
+    when: User changes altitude unit between meters and feet
+    then: The flight detail view displays altitude in the selected unit
+  - id: SC-SYSREQ-008-10
+    name: Change speed unit
+    given: The settings panel is open
+    when: User changes speed unit between km/h and knots
+    then: The flight detail view displays speed in the selected unit
+  - id: SC-SYSREQ-008-11
+    name: Close settings panel
+    given: The settings panel is open
+    when: User taps the "Done" button
+    then: The settings sheet is dismissed
+---
+
+# SYSREQ-008: Settings Panel
+
+## Description
+
+The application provides a settings panel that allows users to configure search radius, auto-refresh interval, map style, unit preferences (altitude and speed), and custom API credentials. All settings are persisted via `UserDefaults` and survive app restarts, development rebuilds, and App Store updates.
+
+## Source Files
+
+- `UpThere/Models/AppSettings.swift` — Settings model and persistence
+- `UpThere/Views/SettingsView.swift` — Settings UI
+- `UpThere/Views/ContentView.swift` — Settings sheet presentation
+- `UpThere/Services/OpenSkyConfig.swift` — `ResolvedCredentials` struct and resolution logic
+- `UpThere/Services/FlightService.swift` — Credential-based initialization
+- `UpThere/ViewModels/UpThereViewModel.swift` — Settings observation and reactive updates
+
+## Acceptance Criteria
+
+1. Settings are accessible via a gear icon button in the toolbar
+2. Settings are presented as a sheet with a `NavigationStack` and `Form` layout
+3. A "Done" button in the toolbar dismisses the settings sheet
+4. Six configuration sections are available: Search Radius, Auto-Refresh, Map Style, Units, API Credentials
+5. All settings are persisted to `UserDefaults` with keys prefixed `upthere.`
+6. Settings changes take effect reactively without requiring an app restart
+7. The `AppSettings` class is `@Observable` and `@MainActor`
+8. The `FlightService` receives `ResolvedCredentials` (a plain struct) to avoid MainActor isolation conflicts
+
+## Search Radius
+
+| Option | Value |
+|--------|-------|
+| 50 km | 50 |
+| 100 km | 100 |
+| 200 km | 200 (default) |
+| 500 km | 500 |
+
+Presented as a `.segmented` picker. The selected value is used as `radiusKm` when building the `BoundingBox` in `refreshFlights()`.
+
+## Auto-Refresh Interval
+
+| Option | Interval |
+|--------|----------|
+| Often | 5 seconds |
+| Medium | 30 seconds |
+| Seldom | 60 seconds |
+| Manual | Disabled (nil) |
+| Custom | User-defined seconds (minimum 1) |
+
+Presented as a `.menu` picker. When "Custom" is selected, a `TextField` appears for entering the number of seconds. When "Manual" is selected, a hint text explains that the user must tap the refresh button manually.
+
+The `effectiveRefreshInterval` computed property returns `nil` for manual mode, which causes `startAutoRefresh()` to skip creating a refresh task.
+
+## Map Style
+
+| Option | MapStyle |
+|--------|----------|
+| Standard (default) | `.standard` |
+| Satellite | `.imagery` |
+| Hybrid | `.hybrid` |
+
+Presented as a `.segmented` picker. Applied to the map via `.mapStyle(settings.mapStyle.mapStyle)` modifier on `FlightMapView`.
+
+## Unit Preferences
+
+### Altitude Unit
+
+| Option | Symbol | Default |
+|--------|--------|---------|
+| Meters (m) | m | Yes |
+| Feet (ft) | ft | No |
+
+The `Flight` model stores altitude in meters (`baroAltitude`) and provides `altitudeFeet` as a computed property. The detail view selects which to display based on the user's preference.
+
+### Speed Unit
+
+| Option | Symbol | Default |
+|--------|--------|---------|
+| km/h | km/h | Yes |
+| Knots (kt) | kt | No |
+
+The `Flight` model stores speed in m/s (`velocity`) and provides `speedKnots` and `speedKmh` as computed properties. The detail view selects which to display based on the user's preference.
+
+## API Credentials
+
+| Field | UI Element | Notes |
+|-------|-----------|-------|
+| Client ID | `TextField` | Autocapitalization disabled (iOS), autocorrection disabled |
+| Client Secret | `SecureField` | Masked input |
+
+- A "Clear Credentials" destructive button appears when credentials are set
+- Info text explains that custom credentials override environment variables
+- Link to opensky-network.org for obtaining credentials
+
+## Credential Resolution Priority
+
+```
+1. Custom settings (Client ID + Client Secret from UserDefaults)
+   ↓ if not configured
+2. Environment variables (OPENSKY_CLIENT_ID + OPENSKY_CLIENT_SECRET)
+   ↓ if not configured
+3. None — unauthenticated mode
+```
+
+The credential source is logged at `info` level on first use:
+```
+Using API credentials from: custom settings
+Using API credentials from: environment variables
+Using API credentials from: none — unauthenticated
+```
+
+## Settings Observation
+
+The `UpThereViewModel` polls settings every 500ms via `observeSettingsChanges()` to detect:
+- **Refresh option changes** → restarts the auto-refresh task with the new interval
+- **Credential changes** → calls `flightService.updateCredentials()` with resolved credentials, clearing the cached token if the source changed
+
+## Persistence Keys
+
+| Key | Type | Default |
+|-----|------|---------|
+| `upthere.searchRadius` | Double | 200 |
+| `upthere.refreshOption` | String | "often" |
+| `upthere.customRefreshSeconds` | Double | 10 |
+| `upthere.mapStyle` | String | "standard" |
+| `upthere.altitudeUnit` | String | "meters" |
+| `upthere.speedUnit` | String | "kmh" |
+| `upthere.customClientId` | String | "" |
+| `upthere.customClientSecret` | String | "" |
+
+## Settings View Layout
+
+```
+┌─────────────────────────────────┐
+│ Settings              [Done]    │
+├─────────────────────────────────┤
+│ Search Radius                   │
+│ [50 km][100 km][200 km][500 km] │
+├─────────────────────────────────┤
+│ Auto-Refresh                    │
+│ Interval: [Often (5 s)      ▼]  │
+├─────────────────────────────────┤
+│ Map Style                       │
+│ [Standard][Satellite][Hybrid]   │
+├─────────────────────────────────┤
+│ Units                           │
+│ Altitude: [Meters (m)       ▼]  │
+│ Speed:    [km/h             ▼]  │
+├─────────────────────────────────┤
+│ API Credentials                 │
+│ Client ID: [____________]       │
+│ Client Secret: [____________]   │
+│ ⓘ Overrides environment vars    │
+│ Get credentials at opensky-...  │
+└─────────────────────────────────┘
+```
+
+## Edge Cases
+
+- Custom refresh seconds below 1 are clamped to 1
+- Changing credentials clears the cached OAuth2 token to force re-authentication
+- Settings are initialized from `UserDefaults` on app launch; missing keys use defaults
+- The `AppSettings` singleton (`shared`) is created at the `@main` app root and injected through the view hierarchy
+- The `FlightService` stores `ResolvedCredentials` (a plain struct) rather than `AppSettings` directly to avoid `@MainActor` isolation conflicts
+- Unit preferences affect only the display layer (`FlightDetailView`), not the underlying data model

--- a/Requirements/core/SYSREQ-008-settings-panel.md
+++ b/Requirements/core/SYSREQ-008-settings-panel.md
@@ -4,7 +4,7 @@ title: Settings Panel
 priority: high
 type: feature
 status: implemented
-tags: [settings, persistence, configuration, user-preferences, units]
+tags: [settings, persistence, configuration, user-preferences, units, aviationstack]
 scenarios:
   - id: SC-SYSREQ-008-01
     name: Open settings panel
@@ -61,6 +61,16 @@ scenarios:
     given: The settings panel is open
     when: User taps the "Done" button
     then: The settings sheet is dismissed
+  - id: SC-SYSREQ-008-12
+    name: Configure AviationStack API key
+    given: The settings panel is open
+    when: User enters an AviationStack API key
+    then: The key is persisted and used for route lookups, overriding the environment variable
+  - id: SC-SYSREQ-008-13
+    name: Clear AviationStack API key
+    given: An AviationStack API key is configured
+    when: User taps "Clear API Key"
+    then: The key is cleared and route lookups fall back to the environment variable
 ---
 
 # SYSREQ-008: Settings Panel
@@ -83,7 +93,7 @@ The application provides a settings panel that allows users to configure search 
 1. Settings are accessible via a gear icon button in the toolbar
 2. Settings are presented as a sheet with a `NavigationStack` and `Form` layout
 3. A "Done" button in the toolbar dismisses the settings sheet
-4. Six configuration sections are available: Search Radius, Auto-Refresh, Map Style, Units, API Credentials
+4. Seven configuration sections are available: Search Radius, Auto-Refresh, Map Style, Units, OpenSky API, AviationStack API
 5. All settings are persisted to `UserDefaults` with keys prefixed `upthere.`
 6. Settings changes take effect reactively without requiring an app restart
 7. The `AppSettings` class is `@Observable` and `@MainActor`
@@ -146,6 +156,8 @@ The `Flight` model stores speed in m/s (`velocity`) and provides `speedKnots` an
 
 ## API Credentials
 
+### OpenSky API
+
 | Field | UI Element | Notes |
 |-------|-----------|-------|
 | Client ID | `TextField` | Autocapitalization disabled (iOS), autocorrection disabled |
@@ -155,7 +167,21 @@ The `Flight` model stores speed in m/s (`velocity`) and provides `speedKnots` an
 - Info text explains that custom credentials override environment variables
 - Link to opensky-network.org for obtaining credentials
 
+### AviationStack API
+
+| Field | UI Element | Notes |
+|-------|-----------|-------|
+| API Key | `SecureField` | Masked input, autocapitalization disabled (iOS) |
+
+- A "Clear API Key" destructive button appears when a key is set
+- Info text explains that the key overrides the `AVIATIONSTACK_API_KEY` environment variable
+- Link to aviationstack.com for obtaining an API key
+- The key is used by `FlightRouteService` to fetch route information (airline, departure/arrival airports, terminals, gates, flight status)
+- When the key changes in settings, the `FlightRouteService` cache is cleared and the new key is used for subsequent lookups
+
 ## Credential Resolution Priority
+
+### OpenSky (OAuth2)
 
 ```
 1. Custom settings (Client ID + Client Secret from UserDefaults)
@@ -172,11 +198,22 @@ Using API credentials from: environment variables
 Using API credentials from: none — unauthenticated
 ```
 
+### AviationStack (API Key)
+
+```
+1. Custom settings (API Key from UserDefaults)
+   ↓ if not configured
+2. Environment variable (AVIATIONSTACK_API_KEY)
+   ↓ if not configured
+3. None — route lookups disabled
+```
+
 ## Settings Observation
 
 The `UpThereViewModel` polls settings every 500ms via `observeSettingsChanges()` to detect:
 - **Refresh option changes** → restarts the auto-refresh task with the new interval
-- **Credential changes** → calls `flightService.updateCredentials()` with resolved credentials, clearing the cached token if the source changed
+- **OpenSky credential changes** → calls `flightService.updateCredentials()` with resolved credentials, clearing the cached token if the source changed
+- **AviationStack API key changes** → calls `routeService.updateApiKey()` with the new key, clearing the route cache
 
 ## Persistence Keys
 
@@ -190,6 +227,7 @@ The `UpThereViewModel` polls settings every 500ms via `observeSettingsChanges()`
 | `upthere.speedUnit` | String | "kmh" |
 | `upthere.customClientId` | String | "" |
 | `upthere.customClientSecret` | String | "" |
+| `upthere.aviationStackApiKey` | String | "" |
 
 ## Settings View Layout
 
@@ -210,11 +248,16 @@ The `UpThereViewModel` polls settings every 500ms via `observeSettingsChanges()`
 │ Altitude: [Meters (m)       ▼]  │
 │ Speed:    [km/h             ▼]  │
 ├─────────────────────────────────┤
-│ API Credentials                 │
+│ OpenSky API                     │
 │ Client ID: [____________]       │
 │ Client Secret: [____________]   │
 │ ⓘ Overrides environment vars    │
 │ Get credentials at opensky-...  │
+├─────────────────────────────────┤
+│ AviationStack API               │
+│ API Key: [____________]         │
+│ ⓘ Overrides environment vars    │
+│ Get API key at aviationstac...  │
 └─────────────────────────────────┘
 ```
 

--- a/UpThere/App/UpThereApp.swift
+++ b/UpThere/App/UpThereApp.swift
@@ -2,9 +2,11 @@ import SwiftUI
 
 @main
 struct UpThereApp: App {
+    @State private var settings = AppSettings.shared
+
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ContentView(settings: settings)
         }
     }
 }

--- a/UpThere/Models/AppSettings.swift
+++ b/UpThere/Models/AppSettings.swift
@@ -86,6 +86,52 @@ enum SearchRadius: Double, CaseIterable, Identifiable {
     }
 }
 
+// MARK: - Unit Preferences
+
+/// Altitude display unit
+enum AltitudeUnit: String, CaseIterable, Identifiable {
+    case meters
+    case feet
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .meters: "Meters (m)"
+        case .feet: "Feet (ft)"
+        }
+    }
+
+    var symbol: String {
+        switch self {
+        case .meters: "m"
+        case .feet: "ft"
+        }
+    }
+}
+
+/// Speed display unit
+enum SpeedUnit: String, CaseIterable, Identifiable {
+    case kmh
+    case knots
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .kmh: "km/h"
+        case .knots: "Knots (kt)"
+        }
+    }
+
+    var symbol: String {
+        switch self {
+        case .kmh: "km/h"
+        case .knots: "kt"
+        }
+    }
+}
+
 // MARK: - AppSettings
 
 /// Application-wide settings persisted via UserDefaults
@@ -138,6 +184,18 @@ final class AppSettings {
         }
     }
 
+    var altitudeUnit: AltitudeUnit {
+        didSet {
+            UserDefaults.standard.set(self.altitudeUnit.rawValue, forKey: Keys.altitudeUnit)
+        }
+    }
+
+    var speedUnit: SpeedUnit {
+        didSet {
+            UserDefaults.standard.set(self.speedUnit.rawValue, forKey: Keys.speedUnit)
+        }
+    }
+
     // MARK: - Computed Helpers
 
     /// The effective refresh interval, or nil when in manual mode
@@ -166,6 +224,8 @@ final class AppSettings {
         static let mapStyle = "upthere.mapStyle"
         static let customClientId = "upthere.customClientId"
         static let customClientSecret = "upthere.customClientSecret"
+        static let altitudeUnit = "upthere.altitudeUnit"
+        static let speedUnit = "upthere.speedUnit"
     }
 
     /// Internal initializer for testing; reads from UserDefaults
@@ -192,6 +252,20 @@ final class AppSettings {
 
         self.customClientId = UserDefaults.standard.string(forKey: Keys.customClientId) ?? ""
         self.customClientSecret = UserDefaults.standard.string(forKey: Keys.customClientSecret) ?? ""
+
+        if let raw = UserDefaults.standard.string(forKey: Keys.altitudeUnit),
+           let unit = AltitudeUnit(rawValue: raw) {
+            self.altitudeUnit = unit
+        } else {
+            self.altitudeUnit = .meters
+        }
+
+        if let raw = UserDefaults.standard.string(forKey: Keys.speedUnit),
+           let unit = SpeedUnit(rawValue: raw) {
+            self.speedUnit = unit
+        } else {
+            self.speedUnit = .kmh
+        }
     }
 
     // MARK: - Test Helpers
@@ -204,6 +278,8 @@ final class AppSettings {
         self.mapStyle = .standard
         self.customClientId = customClientId
         self.customClientSecret = customClientSecret
+        self.altitudeUnit = .meters
+        self.speedUnit = .kmh
     }
 
     /// Create a test instance with a given OpenSkyConfig (bypasses UserDefaults)

--- a/UpThere/Models/AppSettings.swift
+++ b/UpThere/Models/AppSettings.swift
@@ -196,6 +196,12 @@ final class AppSettings {
         }
     }
 
+    var aviationStackApiKey: String {
+        didSet {
+            UserDefaults.standard.set(self.aviationStackApiKey, forKey: Keys.aviationStackApiKey)
+        }
+    }
+
     // MARK: - Computed Helpers
 
     /// The effective refresh interval, or nil when in manual mode
@@ -215,6 +221,17 @@ final class AppSettings {
         !customClientId.isEmpty && !customClientSecret.isEmpty
     }
 
+    /// Whether an AviationStack API key is configured (settings or env var)
+    var hasAviationStackKey: Bool {
+        !aviationStackApiKey.isEmpty || AviationStackConfig.default.isConfigured
+    }
+
+    /// Resolve the AviationStack API key with priority: settings → env var
+    var resolvedAviationStackKey: String? {
+        if !aviationStackApiKey.isEmpty { return aviationStackApiKey }
+        return AviationStackConfig.default.apiKey
+    }
+
     // MARK: - Private
 
     private enum Keys {
@@ -226,6 +243,7 @@ final class AppSettings {
         static let customClientSecret = "upthere.customClientSecret"
         static let altitudeUnit = "upthere.altitudeUnit"
         static let speedUnit = "upthere.speedUnit"
+        static let aviationStackApiKey = "upthere.aviationStackApiKey"
     }
 
     /// Internal initializer for testing; reads from UserDefaults
@@ -266,12 +284,14 @@ final class AppSettings {
         } else {
             self.speedUnit = .kmh
         }
+
+        self.aviationStackApiKey = UserDefaults.standard.string(forKey: Keys.aviationStackApiKey) ?? ""
     }
 
     // MARK: - Test Helpers
 
     /// Private initializer that bypasses UserDefaults (for testing)
-    private init(customClientId: String, customClientSecret: String) {
+    private init(customClientId: String, customClientSecret: String, aviationStackApiKey: String = "") {
         self.searchRadius = .twoHundred
         self.refreshOption = .often
         self.customRefreshSeconds = 10
@@ -280,6 +300,7 @@ final class AppSettings {
         self.customClientSecret = customClientSecret
         self.altitudeUnit = .meters
         self.speedUnit = .kmh
+        self.aviationStackApiKey = aviationStackApiKey
     }
 
     /// Create a test instance with a given OpenSkyConfig (bypasses UserDefaults)

--- a/UpThere/Models/AppSettings.swift
+++ b/UpThere/Models/AppSettings.swift
@@ -1,0 +1,216 @@
+import Foundation
+import Observation
+import MapKit
+import SwiftUI
+
+// MARK: - Refresh Interval Options
+
+/// User-selectable refresh interval presets
+enum RefreshIntervalOption: String, CaseIterable, Identifiable {
+    case often
+    case medium
+    case seldom
+    case manual
+    case custom
+
+    var id: String { rawValue }
+
+    /// The fixed interval in seconds for preset options, or nil for manual/custom
+    var presetSeconds: TimeInterval? {
+        switch self {
+        case .often: 5
+        case .medium: 30
+        case .seldom: 60
+        case .manual: nil
+        case .custom: nil
+        }
+    }
+
+    /// Display label shown in the settings picker
+    var displayName: String {
+        switch self {
+        case .often: "Often (5 s)"
+        case .medium: "Medium (30 s)"
+        case .seldom: "Seldom (60 s)"
+        case .manual: "Manual"
+        case .custom: "Custom"
+        }
+    }
+}
+
+// MARK: - Map Style
+
+/// Map display style options
+enum AppMapStyle: String, CaseIterable, Identifiable {
+    case standard
+    case satellite
+    case hybrid
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .standard: "Standard"
+        case .satellite: "Satellite"
+        case .hybrid: "Hybrid"
+        }
+    }
+
+    var mapStyle: MapStyle {
+        switch self {
+        case .standard: .standard
+        case .satellite: .imagery
+        case .hybrid: .hybrid
+        }
+    }
+}
+
+// MARK: - Search Radius Options
+
+/// Search radius options in kilometers
+enum SearchRadius: Double, CaseIterable, Identifiable {
+    case fifty = 50
+    case oneHundred = 100
+    case twoHundred = 200
+    case fiveHundred = 500
+
+    var id: Double { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .fifty: "50 km"
+        case .oneHundred: "100 km"
+        case .twoHundred: "200 km"
+        case .fiveHundred: "500 km"
+        }
+    }
+}
+
+// MARK: - AppSettings
+
+/// Application-wide settings persisted via UserDefaults
+@Observable
+@MainActor
+final class AppSettings {
+
+    // MARK: - Shared Instance
+
+    static let shared = AppSettings()
+
+    // MARK: - Public Properties
+
+    var searchRadius: SearchRadius {
+        didSet {
+            UserDefaults.standard.set(self.searchRadius.rawValue, forKey: Keys.searchRadius)
+            AppLogger.viewModel.debug("Settings: search radius changed to \(self.searchRadius.displayName, privacy: .public)")
+        }
+    }
+
+    var refreshOption: RefreshIntervalOption {
+        didSet {
+            UserDefaults.standard.set(self.refreshOption.rawValue, forKey: Keys.refreshOption)
+            AppLogger.viewModel.debug("Settings: refresh option changed to \(self.refreshOption.displayName, privacy: .public)")
+        }
+    }
+
+    var customRefreshSeconds: Double {
+        didSet {
+            UserDefaults.standard.set(self.customRefreshSeconds, forKey: Keys.customRefreshSeconds)
+        }
+    }
+
+    var mapStyle: AppMapStyle {
+        didSet {
+            UserDefaults.standard.set(self.mapStyle.rawValue, forKey: Keys.mapStyle)
+            AppLogger.viewModel.debug("Settings: map style changed to \(self.mapStyle.displayName, privacy: .public)")
+        }
+    }
+
+    var customClientId: String {
+        didSet {
+            UserDefaults.standard.set(self.customClientId, forKey: Keys.customClientId)
+        }
+    }
+
+    var customClientSecret: String {
+        didSet {
+            UserDefaults.standard.set(self.customClientSecret, forKey: Keys.customClientSecret)
+        }
+    }
+
+    // MARK: - Computed Helpers
+
+    /// The effective refresh interval, or nil when in manual mode
+    var effectiveRefreshInterval: TimeInterval? {
+        switch refreshOption {
+        case .manual:
+            return nil
+        case .custom:
+            return max(customRefreshSeconds, 1)
+        case .often, .medium, .seldom:
+            return refreshOption.presetSeconds
+        }
+    }
+
+    /// Whether custom API credentials are configured in settings
+    var hasCustomCredentials: Bool {
+        !customClientId.isEmpty && !customClientSecret.isEmpty
+    }
+
+    // MARK: - Private
+
+    private enum Keys {
+        static let searchRadius = "upthere.searchRadius"
+        static let refreshOption = "upthere.refreshOption"
+        static let customRefreshSeconds = "upthere.customRefreshSeconds"
+        static let mapStyle = "upthere.mapStyle"
+        static let customClientId = "upthere.customClientId"
+        static let customClientSecret = "upthere.customClientSecret"
+    }
+
+    /// Internal initializer for testing; reads from UserDefaults
+    init() {
+        let storedRadius = UserDefaults.standard.double(forKey: Keys.searchRadius)
+        self.searchRadius = SearchRadius(rawValue: storedRadius) ?? .twoHundred
+
+        if let raw = UserDefaults.standard.string(forKey: Keys.refreshOption),
+           let option = RefreshIntervalOption(rawValue: raw) {
+            self.refreshOption = option
+        } else {
+            self.refreshOption = .often
+        }
+
+        let storedCustomSeconds = UserDefaults.standard.double(forKey: Keys.customRefreshSeconds)
+        self.customRefreshSeconds = storedCustomSeconds > 0 ? storedCustomSeconds : 10
+
+        if let raw = UserDefaults.standard.string(forKey: Keys.mapStyle),
+           let style = AppMapStyle(rawValue: raw) {
+            self.mapStyle = style
+        } else {
+            self.mapStyle = .standard
+        }
+
+        self.customClientId = UserDefaults.standard.string(forKey: Keys.customClientId) ?? ""
+        self.customClientSecret = UserDefaults.standard.string(forKey: Keys.customClientSecret) ?? ""
+    }
+
+    // MARK: - Test Helpers
+
+    /// Private initializer that bypasses UserDefaults (for testing)
+    private init(customClientId: String, customClientSecret: String) {
+        self.searchRadius = .twoHundred
+        self.refreshOption = .often
+        self.customRefreshSeconds = 10
+        self.mapStyle = .standard
+        self.customClientId = customClientId
+        self.customClientSecret = customClientSecret
+    }
+
+    /// Create a test instance with a given OpenSkyConfig (bypasses UserDefaults)
+    static func testConfig(_ config: OpenSkyConfig) -> AppSettings {
+        AppSettings(
+            customClientId: config.clientId ?? "",
+            customClientSecret: config.clientSecret ?? ""
+        )
+    }
+}

--- a/UpThere/Models/Flight.swift
+++ b/UpThere/Models/Flight.swift
@@ -57,6 +57,12 @@ struct Flight: Identifiable, Hashable {
         return speed * 1.94384
     }
     
+    /// Speed in km/h (converted from m/s)
+    var speedKmh: Double? {
+        guard let speed = velocity else { return nil }
+        return speed * 3.6
+    }
+    
     /// Vertical rate in feet per minute (converted from m/s)
     var verticalRateFPM: Double? {
         guard let rate = verticalRate else { return nil }

--- a/UpThere/Services/FlightRouteService.swift
+++ b/UpThere/Services/FlightRouteService.swift
@@ -3,15 +3,15 @@ import os
 
 /// Service for fetching flight route information from AviationStack API
 actor FlightRouteService {
-    private let config: AviationStackConfig
+    private var apiKey: String?
     private let session: URLSession
     
     /// In-memory cache for route info, keyed by ICAO24
     private var cache: [String: FlightRouteInfo] = [:]
     
     /// Initializer for production use
-    nonisolated init(config: AviationStackConfig = .default) {
-        self.config = config
+    init(apiKey: String?) {
+        self.apiKey = apiKey
         
         let configuration = URLSessionConfiguration.default
         configuration.timeoutIntervalForRequest = 15
@@ -21,9 +21,17 @@ actor FlightRouteService {
     }
     
     /// Initializer with custom URLSession (for testing)
-    nonisolated init(config: AviationStackConfig, session: URLSession) {
-        self.config = config
+    init(apiKey: String?, session: URLSession) {
+        self.apiKey = apiKey
         self.session = session
+    }
+    
+    /// Update API key when settings change
+    func updateApiKey(_ newKey: String?) {
+        if apiKey != newKey {
+            apiKey = newKey
+            cache.removeAll()
+        }
     }
     
     /// Fetch route information for a flight
@@ -36,7 +44,7 @@ actor FlightRouteService {
             return cached
         }
         
-        guard config.isConfigured else {
+        guard let apiKey = apiKey, !apiKey.isEmpty else {
             AppLogger.flightService.warning("AviationStack not configured, skipping route lookup")
             return nil
         }
@@ -46,7 +54,7 @@ actor FlightRouteService {
             return nil
         }
         
-        let url = try buildURL(for: callsign)
+        let url = try buildURL(for: callsign, apiKey: apiKey)
         AppLogger.flightService.debug("Fetching route info: \(url.absoluteString, privacy: .public)")
         
         let request = URLRequest(url: url)
@@ -95,12 +103,8 @@ actor FlightRouteService {
     }
     
     /// Build URL with query parameters for AviationStack flights endpoint
-    private func buildURL(for callsign: String) throws -> URL {
-        guard let apiKey = config.apiKey else {
-            throw AviationStackError.unauthorized
-        }
-        
-        var components = URLComponents(string: "\(config.baseURL)/flights")
+    private func buildURL(for callsign: String, apiKey: String) throws -> URL {
+        var components = URLComponents(string: "https://api.aviationstack.com/v1/flights")
         components?.queryItems = [
             URLQueryItem(name: "access_key", value: apiKey),
             URLQueryItem(name: "flight_icao", value: callsign)

--- a/UpThere/Services/FlightService.swift
+++ b/UpThere/Services/FlightService.swift
@@ -3,18 +3,21 @@ import os
 
 /// Service for fetching flight data from OpenSky Network API
 actor FlightService {
-    private let config: OpenSkyConfig
+    private var credentials: ResolvedCredentials
     private let session: URLSession
     
     // OAuth2 token management
     private var accessToken: String?
     private var tokenExpiresAt: Date?
     
+    // Track which credential source was last used (for logging)
+    private var lastCredentialSource: String?
+    
     private let decoder = JSONDecoder()
     
     /// Initializer for production use
-    nonisolated init(config: OpenSkyConfig = .default) {
-        self.config = config
+    init(credentials: ResolvedCredentials) {
+        self.credentials = credentials
         
         let configuration = URLSessionConfiguration.default
         configuration.timeoutIntervalForRequest = 30
@@ -23,20 +26,38 @@ actor FlightService {
     }
     
     /// Initializer with custom URLSession (for testing)
-    nonisolated init(config: OpenSkyConfig, session: URLSession) {
-        self.config = config
+    init(credentials: ResolvedCredentials, session: URLSession) {
+        self.credentials = credentials
         self.session = session
+    }
+    
+    /// Update credentials when settings change
+    func updateCredentials(_ newCredentials: ResolvedCredentials) {
+        // Clear cached token when credentials change
+        if credentials.sourceDescription != newCredentials.sourceDescription {
+            accessToken = nil
+            tokenExpiresAt = nil
+        }
+        credentials = newCredentials
+    }
+    
+    /// Log the credential source once at first use
+    private func logCredentialSource(_ source: String) {
+        guard lastCredentialSource != source else { return }
+        lastCredentialSource = source
+        AppLogger.flightService.info("Using API credentials from: \(source, privacy: .public)")
     }
     
     /// Fetch all flights within a bounding box
     func fetchFlights(in boundingBox: BoundingBox) async throws -> [Flight] {
+        logCredentialSource(credentials.sourceDescription)
         let url = try buildURL(for: boundingBox)
         AppLogger.flightService.debug("Fetching flights: \(url.absoluteString, privacy: .public)")
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         
         // Add authentication if configured
-        if config.isConfigured {
+        if credentials.isConfigured {
             let token = try await getAccessToken()
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
@@ -60,7 +81,7 @@ actor FlightService {
                 AppLogger.flightService.warning("Received 401, refreshing token and retrying")
                 accessToken = nil
                 tokenExpiresAt = nil
-                if config.isConfigured {
+                if credentials.isConfigured {
                     let newToken = try await getAccessToken()
                     return try await fetchFlightsWithToken(newToken, boundingBox: boundingBox)
                 }
@@ -121,7 +142,7 @@ actor FlightService {
             return token
         }
         
-        guard config.isConfigured else {
+        guard credentials.isConfigured else {
             throw OpenSkyError.unauthorized
         }
         
@@ -130,12 +151,12 @@ actor FlightService {
     
     /// Refresh the OAuth2 access token
     private func refreshToken() async throws -> String {
-        guard let clientId = config.clientId,
-              let clientSecret = config.clientSecret else {
+        guard let clientId = credentials.clientId,
+              let clientSecret = credentials.clientSecret else {
             throw OpenSkyError.unauthorized
         }
         
-        let authURL = URL(string: config.authURL)!
+        let authURL = URL(string: OpenSkyConfig.default.authURL)!
         var request = URLRequest(url: authURL)
         request.httpMethod = "POST"
         request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
@@ -186,7 +207,7 @@ actor FlightService {
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
 
-        if config.isConfigured {
+        if credentials.isConfigured {
             let token = try await getAccessToken()
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
@@ -209,7 +230,7 @@ actor FlightService {
                 AppLogger.flightService.warning("Received 401 from history API, refreshing token and retrying")
                 accessToken = nil
                 tokenExpiresAt = nil
-                if config.isConfigured {
+                if credentials.isConfigured {
                     let newToken = try await getAccessToken()
                     return try await fetchFlightHistoryWithToken(newToken, icao24: icao24, timeFrom: timeFrom, timeTo: timeTo)
                 }
@@ -260,7 +281,7 @@ actor FlightService {
 
     /// Build URL with query parameters
     private func buildURL(for boundingBox: BoundingBox) throws -> URL {
-        var components = URLComponents(string: "\(config.baseURL)/states/all")
+        var components = URLComponents(string: "\(OpenSkyConfig.default.baseURL)/states/all")
         components?.queryItems = boundingBox.queryItems
 
         guard let url = components?.url else {
@@ -272,7 +293,7 @@ actor FlightService {
 
     /// Build URL for the flight history endpoint
     private func buildHistoryURL(icao24: String, timeFrom: Int, timeTo: Int) throws -> URL {
-        var components = URLComponents(string: "\(config.baseURL)/api/states/all")
+        var components = URLComponents(string: "\(OpenSkyConfig.default.baseURL)/api/states/all")
         components?.queryItems = [
             URLQueryItem(name: "icao24", value: icao24),
             URLQueryItem(name: "time", value: String(timeFrom)),

--- a/UpThere/Services/OpenSkyConfig.swift
+++ b/UpThere/Services/OpenSkyConfig.swift
@@ -36,3 +36,53 @@ struct OpenSkyConfig {
         self.clientSecret = clientSecret
     }
 }
+
+// MARK: - Credential Resolution
+
+/// Result of resolving API credentials from multiple sources
+struct ResolvedCredentials {
+    let clientId: String?
+    let clientSecret: String?
+    /// Human-readable description of the source used, for logging
+    let sourceDescription: String
+
+    var isConfigured: Bool {
+        guard let clientId = clientId, !clientId.isEmpty,
+              let clientSecret = clientSecret, !clientSecret.isEmpty else {
+            return false
+        }
+        return true
+    }
+}
+
+extension ResolvedCredentials {
+    /// Resolve credentials with priority: custom settings → environment variables
+    @MainActor
+    static func resolve(from settings: AppSettings) -> ResolvedCredentials {
+        // Priority 1: Custom credentials from settings
+        if settings.hasCustomCredentials {
+            return ResolvedCredentials(
+                clientId: settings.customClientId,
+                clientSecret: settings.customClientSecret,
+                sourceDescription: "custom settings"
+            )
+        }
+
+        // Priority 2: Environment variables
+        let envConfig = OpenSkyConfig.default
+        if envConfig.isConfigured {
+            return ResolvedCredentials(
+                clientId: envConfig.clientId,
+                clientSecret: envConfig.clientSecret,
+                sourceDescription: "environment variables"
+            )
+        }
+
+        // No credentials available
+        return ResolvedCredentials(
+            clientId: nil,
+            clientSecret: nil,
+            sourceDescription: "none — unauthenticated"
+        )
+    }
+}

--- a/UpThere/ViewModels/UpThereViewModel.swift
+++ b/UpThere/ViewModels/UpThereViewModel.swift
@@ -67,7 +67,7 @@ class UpThereViewModel {
         let credentials = ResolvedCredentials.resolve(from: settings)
         self.flightService = FlightService(credentials: credentials)
         self.locationService = LocationService()
-        self.routeService = FlightRouteService()
+        self.routeService = FlightRouteService(apiKey: settings.resolvedAviationStackKey)
     }
     
     // MARK: - Public Methods
@@ -267,6 +267,7 @@ class UpThereViewModel {
             guard let self = self else { return }
             var lastRefreshOption = self.settings.refreshOption
             var lastHasCredentials = self.settings.hasCustomCredentials
+            var lastAviationStackKey = self.settings.resolvedAviationStackKey
             
             while !Task.isCancelled {
                 try? await Task.sleep(nanoseconds: 500_000_000) // poll every 500ms
@@ -274,6 +275,7 @@ class UpThereViewModel {
                 
                 let currentRefreshOption = self.settings.refreshOption
                 let currentHasCredentials = self.settings.hasCustomCredentials
+                let currentAviationStackKey = self.settings.resolvedAviationStackKey
                 
                 // Restart auto-refresh if interval option changed
                 if currentRefreshOption != lastRefreshOption {
@@ -286,6 +288,12 @@ class UpThereViewModel {
                     lastHasCredentials = currentHasCredentials
                     let credentials = ResolvedCredentials.resolve(from: self.settings)
                     await self.flightService.updateCredentials(credentials)
+                }
+                
+                // Update AviationStack API key if it changed
+                if currentAviationStackKey != lastAviationStackKey {
+                    lastAviationStackKey = currentAviationStackKey
+                    await self.routeService.updateApiKey(currentAviationStackKey)
                 }
             }
         }

--- a/UpThere/ViewModels/UpThereViewModel.swift
+++ b/UpThere/ViewModels/UpThereViewModel.swift
@@ -33,6 +33,7 @@ class UpThereViewModel {
     private let flightService: FlightService
     private let locationService: LocationService
     private let routeService: FlightRouteService
+    private let settings: AppSettings
     
     // MARK: - Configuration
     /// Search radius in kilometers (default 200km)
@@ -58,10 +59,13 @@ class UpThereViewModel {
     
     // MARK: - Private
     private var refreshTask: Task<Void, Never>?
+    private var settingsObserverTask: Task<Void, Never>?
     
     // MARK: - Initialization
-    init() {
-        self.flightService = FlightService()
+    init(settings: AppSettings = .shared) {
+        self.settings = settings
+        let credentials = ResolvedCredentials.resolve(from: settings)
+        self.flightService = FlightService(credentials: credentials)
         self.locationService = LocationService()
         self.routeService = FlightRouteService()
     }
@@ -72,6 +76,7 @@ class UpThereViewModel {
     func startTracking() {
         AppLogger.viewModel.info("Starting flight tracking")
         locationService.startUpdating()
+        observeSettingsChanges()
         startAutoRefresh()
         Task {
             await refreshFlights()
@@ -82,6 +87,8 @@ class UpThereViewModel {
     func stopTracking() {
         AppLogger.viewModel.info("Stopping flight tracking")
         stopAutoRefresh()
+        settingsObserverTask?.cancel()
+        settingsObserverTask = nil
         locationService.stopUpdating()
         trails.removeAll()
         selectedFlightTrail = nil
@@ -104,7 +111,7 @@ class UpThereViewModel {
             let boundingBox = BoundingBox.around(
                 latitude: location.coordinate.latitude,
                 longitude: location.coordinate.longitude,
-                radiusKm: searchRadiusKm
+                radiusKm: settings.searchRadius.rawValue
             )
             AppLogger.viewModel.debug("Fetching flights in bounding box")
             
@@ -253,17 +260,56 @@ class UpThereViewModel {
     
     // MARK: - Private Methods
     
+    /// Observe settings changes and react accordingly
+    private func observeSettingsChanges() {
+        settingsObserverTask?.cancel()
+        settingsObserverTask = Task { [weak self] in
+            guard let self = self else { return }
+            var lastRefreshOption = self.settings.refreshOption
+            var lastHasCredentials = self.settings.hasCustomCredentials
+            
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 500_000_000) // poll every 500ms
+                guard !Task.isCancelled else { return }
+                
+                let currentRefreshOption = self.settings.refreshOption
+                let currentHasCredentials = self.settings.hasCustomCredentials
+                
+                // Restart auto-refresh if interval option changed
+                if currentRefreshOption != lastRefreshOption {
+                    lastRefreshOption = currentRefreshOption
+                    self.startAutoRefresh()
+                }
+                
+                // Update FlightService credentials if they changed
+                if currentHasCredentials != lastHasCredentials {
+                    lastHasCredentials = currentHasCredentials
+                    let credentials = ResolvedCredentials.resolve(from: self.settings)
+                    await self.flightService.updateCredentials(credentials)
+                }
+            }
+        }
+    }
+    
     private func startAutoRefresh() {
         stopAutoRefresh()
+        
+        // Manual mode: no auto-refresh
+        guard let interval = settings.effectiveRefreshInterval else {
+            AppLogger.viewModel.info("Auto-refresh disabled (manual mode)")
+            return
+        }
+        
         refreshTask = Task { [weak self] in
             guard let self = self else { return }
             while !Task.isCancelled {
-                try? await Task.sleep(nanoseconds: UInt64(self.refreshInterval * 1_000_000_000))
+                try? await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
                 if !Task.isCancelled {
                     await self.refreshFlights()
                 }
             }
         }
+        AppLogger.viewModel.debug("Auto-refresh started with interval: \(interval, privacy: .public)s")
     }
     
     private func stopAutoRefresh() {

--- a/UpThere/Views/ContentView.swift
+++ b/UpThere/Views/ContentView.swift
@@ -21,6 +21,7 @@ struct ContentView: View {
                 NavigationSplitView(columnVisibility: $columnVisibility) {
                     FlightListView(
                         viewModel: viewModel,
+                        settings: settings,
                         onFlightTapped: { viewModel.selectFlight($0) },
                         showDetail: $showDetail,
                         isSidebarVisible: columnVisibility != .detailOnly
@@ -49,6 +50,7 @@ struct ContentView: View {
                     
                     FlightListView(
                         viewModel: viewModel,
+                        settings: settings,
                         onFlightTapped: { viewModel.selectFlight($0) },
                         showDetail: $showDetail
                     )

--- a/UpThere/Views/ContentView.swift
+++ b/UpThere/Views/ContentView.swift
@@ -83,17 +83,5 @@ struct ContentView: View {
                 }
             }
         }
-        .sheet(isPresented: $isShowingSettings) {
-            SettingsView(settings: settings)
-        }
-        .toolbar {
-            ToolbarItem(placement: .primaryAction) {
-                Button {
-                    isShowingSettings = true
-                } label: {
-                    Image(systemName: "gearshape")
-                }
-            }
-        }
     }
 }

--- a/UpThere/Views/ContentView.swift
+++ b/UpThere/Views/ContentView.swift
@@ -2,10 +2,17 @@ import SwiftUI
 
 /// Adaptive content view - split view on iPad, tab view on iPhone
 struct ContentView: View {
-    @State private var viewModel = UpThereViewModel()
+    @State private var viewModel: UpThereViewModel
+    @State private var settings: AppSettings
     @State private var showDetail = false
     @State private var columnVisibility = NavigationSplitViewVisibility.automatic
+    @State private var isShowingSettings = false
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    
+    init(settings: AppSettings = .shared) {
+        self.settings = settings
+        self._viewModel = State(initialValue: UpThereViewModel(settings: settings))
+    }
     
     var body: some View {
         Group {
@@ -22,6 +29,7 @@ struct ContentView: View {
                 } detail: {
                     FlightMapView(
                         viewModel: viewModel,
+                        settings: settings,
                         onFlightTapped: { viewModel.selectFlight($0) },
                         showDetail: $showDetail
                     )
@@ -31,6 +39,7 @@ struct ContentView: View {
                 TabView {
                     FlightMapView(
                         viewModel: viewModel,
+                        settings: settings,
                         onFlightTapped: { viewModel.selectFlight($0) },
                         showDetail: $showDetail
                     )
@@ -58,6 +67,18 @@ struct ContentView: View {
         .sheet(isPresented: $showDetail) {
             if let flight = viewModel.selectedFlight {
                 FlightDetailView(flight: flight, viewModel: viewModel)
+            }
+        }
+        .sheet(isPresented: $isShowingSettings) {
+            SettingsView(settings: settings)
+        }
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    isShowingSettings = true
+                } label: {
+                    Image(systemName: "gearshape")
+                }
             }
         }
     }

--- a/UpThere/Views/ContentView.swift
+++ b/UpThere/Views/ContentView.swift
@@ -66,7 +66,7 @@ struct ContentView: View {
         }
         .sheet(isPresented: $showDetail) {
             if let flight = viewModel.selectedFlight {
-                FlightDetailView(flight: flight, viewModel: viewModel)
+                FlightDetailView(flight: flight, viewModel: viewModel, settings: settings)
             }
         }
         .sheet(isPresented: $isShowingSettings) {

--- a/UpThere/Views/ContentView.swift
+++ b/UpThere/Views/ContentView.swift
@@ -83,5 +83,17 @@ struct ContentView: View {
                 }
             }
         }
+        .sheet(isPresented: $isShowingSettings) {
+            SettingsView(settings: settings)
+        }
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    isShowingSettings = true
+                } label: {
+                    Image(systemName: "gearshape")
+                }
+            }
+        }
     }
 }

--- a/UpThere/Views/FlightDetailView.swift
+++ b/UpThere/Views/FlightDetailView.swift
@@ -5,6 +5,7 @@ import MapKit
 struct FlightDetailView: View {
     let flight: Flight
     @Bindable var viewModel: UpThereViewModel
+    @Bindable var settings: AppSettings
     @Environment(\.dismiss) private var dismiss
     
     @State private var cameraPosition: MapCameraPosition = .automatic
@@ -59,18 +60,18 @@ struct FlightDetailView: View {
                     // Position
                     Group {
                         Text("Position").font(.headline)
-                        if let altitude = flight.altitudeFeet {
+                        if let altitude = settings.altitudeUnit == .meters ? flight.baroAltitude : flight.altitudeFeet {
                             HStack {
                                 Text("Altitude:")
                                 Spacer()
-                                Text("\(Int(altitude).formatted()) ft").fontWeight(.medium)
+                                Text("\(Int(altitude).formatted()) \(settings.altitudeUnit.symbol)").fontWeight(.medium)
                             }
                         }
-                        if let speed = flight.speedKnots {
+                        if let speed = settings.speedUnit == .kmh ? flight.speedKmh : flight.speedKnots {
                             HStack {
                                 Text("Speed:")
                                 Spacer()
-                                Text("\(Int(speed)) knots").fontWeight(.medium)
+                                Text("\(Int(speed)) \(settings.speedUnit.symbol)").fontWeight(.medium)
                             }
                         }
                         if let track = flight.trueTrack {

--- a/UpThere/Views/FlightListView.swift
+++ b/UpThere/Views/FlightListView.swift
@@ -4,6 +4,7 @@ import CoreLocation
 /// List view showing all flights
 struct FlightListView: View {
     @Bindable var viewModel: UpThereViewModel
+    @Bindable var settings: AppSettings
     var onFlightTapped: FlightSelectionHandler?
     @Binding var showDetail: Bool
     @State private var sortOrder = SortOrder.distance
@@ -37,6 +38,7 @@ struct FlightListView: View {
             FlightRowView(
                 flight: flight,
                 userLocation: viewModel.userLocation,
+                settings: settings,
                 isSelected: viewModel.selectedFlight?.id == flight.id,
                 onTapped: { onFlightTapped?(flight) },
                 showDetail: $showDetail
@@ -104,6 +106,7 @@ struct FlightListView: View {
 struct FlightRowView: View {
     let flight: Flight
     let userLocation: CLLocation?
+    @Bindable var settings: AppSettings
     let isSelected: Bool
     let onTapped: () -> Void
     @Binding var showDetail: Bool
@@ -135,14 +138,14 @@ struct FlightRowView: View {
                     .fontWeight(.bold)
                 
                 HStack(spacing: 8) {
-                    if let altitude = flight.altitudeFeet {
-                        Label("\(Int(altitude).formatted()) ft", systemImage: "arrow.up.and.down")
+                    if let altitude = settings.altitudeUnit == .meters ? flight.baroAltitude : flight.altitudeFeet {
+                        Label("\(Int(altitude).formatted()) \(settings.altitudeUnit.symbol)", systemImage: "arrow.up.and.down")
                             .font(.caption)
                             .foregroundColor(.secondary)
                     }
                     
-                    if let speed = flight.speedKnots {
-                        Label("\(Int(speed)) kts", systemImage: "speedometer")
+                    if let speed = settings.speedUnit == .kmh ? flight.speedKmh : flight.speedKnots {
+                        Label("\(Int(speed)) \(settings.speedUnit.symbol)", systemImage: "speedometer")
                             .font(.caption)
                             .foregroundColor(.secondary)
                     }

--- a/UpThere/Views/FlightMapView.swift
+++ b/UpThere/Views/FlightMapView.swift
@@ -7,6 +7,7 @@ typealias FlightSelectionHandler = (Flight) -> Void
 /// Map view showing flights as annotations
 struct FlightMapView: View {
     @Bindable var viewModel: UpThereViewModel
+    @Bindable var settings: AppSettings
     var onFlightTapped: FlightSelectionHandler?
     @Binding var showDetail: Bool
     
@@ -60,6 +61,7 @@ struct FlightMapView: View {
                 // Tap on empty map area → deselect
                 viewModel.selectFlight(nil)
             }
+            .mapStyle(settings.mapStyle.mapStyle)
             .mapControls {
                 MapUserLocationButton()
                 MapCompass()

--- a/UpThere/Views/SettingsView.swift
+++ b/UpThere/Views/SettingsView.swift
@@ -1,0 +1,122 @@
+import SwiftUI
+
+/// Settings view for configuring app preferences
+struct SettingsView: View {
+    @Bindable var settings: AppSettings
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                searchRadiusSection
+                refreshIntervalSection
+                mapStyleSection
+                apiCredentialsSection
+            }
+            #if os(macOS)
+            .formStyle(.grouped)
+            #endif
+            .navigationTitle("Settings")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Search Radius
+
+    private var searchRadiusSection: some View {
+        Section("Search Radius") {
+            Picker("Radius", selection: $settings.searchRadius) {
+                ForEach(SearchRadius.allCases) { radius in
+                    Text(radius.displayName).tag(radius)
+                }
+            }
+            .pickerStyle(.segmented)
+        }
+    }
+
+    // MARK: - Refresh Interval
+
+    @ViewBuilder
+    private var refreshIntervalSection: some View {
+        Section("Auto-Refresh") {
+            Picker("Interval", selection: $settings.refreshOption) {
+                ForEach(RefreshIntervalOption.allCases) { option in
+                    Text(option.displayName).tag(option)
+                }
+            }
+            .pickerStyle(.menu)
+
+            if settings.refreshOption == .custom {
+                HStack {
+                    Text("Custom interval")
+                    Spacer()
+                    TextField("Seconds", value: $settings.customRefreshSeconds, format: .number)
+                        #if os(iOS)
+                        .keyboardType(.numberPad)
+                        #endif
+                        .multilineTextAlignment(.trailing)
+                        .frame(width: 80)
+                    Text("s")
+                        .foregroundColor(.secondary)
+                }
+            }
+
+            if settings.refreshOption == .manual {
+                Label("Tap the refresh button on the map to update manually", systemImage: "hand.tap")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+
+    // MARK: - Map Style
+
+    private var mapStyleSection: some View {
+        Section("Map Style") {
+            Picker("Style", selection: $settings.mapStyle) {
+                ForEach(AppMapStyle.allCases) { style in
+                    Text(style.displayName).tag(style)
+                }
+            }
+            .pickerStyle(.segmented)
+        }
+    }
+
+    // MARK: - API Credentials
+
+    @ViewBuilder
+    private var apiCredentialsSection: some View {
+        Section("API Credentials") {
+            TextField("Client ID", text: $settings.customClientId)
+                #if os(iOS)
+                .textInputAutocapitalization(.never)
+                #endif
+                .autocorrectionDisabled()
+
+            SecureField("Client Secret", text: $settings.customClientSecret)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Label("Overrides environment variables", systemImage: "info.circle")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                Link("Get credentials at opensky-network.org",
+                     destination: URL(string: "https://opensky-network.org/")!)
+                    .font(.caption)
+            }
+            .padding(.top, 2)
+
+            if settings.hasCustomCredentials {
+                Button("Clear Credentials", role: .destructive) {
+                    settings.customClientId = ""
+                    settings.customClientSecret = ""
+                }
+            }
+        }
+    }
+}

--- a/UpThere/Views/SettingsView.swift
+++ b/UpThere/Views/SettingsView.swift
@@ -12,7 +12,8 @@ struct SettingsView: View {
                 refreshIntervalSection
                 mapStyleSection
                 unitsSection
-                apiCredentialsSection
+                openSkyCredentialsSection
+                aviationStackSection
             }
             #if os(macOS)
             .formStyle(.grouped)
@@ -106,11 +107,10 @@ struct SettingsView: View {
         }
     }
 
-    // MARK: - API Credentials
+    // MARK: - OpenSky API Credentials
 
-    @ViewBuilder
-    private var apiCredentialsSection: some View {
-        Section("API Credentials") {
+    private var openSkyCredentialsSection: some View {
+        Section("OpenSky API") {
             TextField("Client ID", text: $settings.customClientId)
                 #if os(iOS)
                 .textInputAutocapitalization(.never)
@@ -133,6 +133,34 @@ struct SettingsView: View {
                 Button("Clear Credentials", role: .destructive) {
                     settings.customClientId = ""
                     settings.customClientSecret = ""
+                }
+            }
+        }
+    }
+
+    // MARK: - AviationStack API
+
+    private var aviationStackSection: some View {
+        Section("AviationStack API") {
+            SecureField("API Key", text: $settings.aviationStackApiKey)
+                #if os(iOS)
+                .textInputAutocapitalization(.never)
+                #endif
+                .autocorrectionDisabled()
+
+            VStack(alignment: .leading, spacing: 4) {
+                Label("Overrides environment variables", systemImage: "info.circle")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                Link("Get API key at aviationstack.com",
+                     destination: URL(string: "https://aviationstack.com/")!)
+                    .font(.caption)
+            }
+            .padding(.top, 2)
+
+            if !settings.aviationStackApiKey.isEmpty {
+                Button("Clear API Key", role: .destructive) {
+                    settings.aviationStackApiKey = ""
                 }
             }
         }

--- a/UpThere/Views/SettingsView.swift
+++ b/UpThere/Views/SettingsView.swift
@@ -109,6 +109,7 @@ struct SettingsView: View {
 
     // MARK: - OpenSky API Credentials
 
+    @ViewBuilder
     private var openSkyCredentialsSection: some View {
         Section("OpenSky API") {
             TextField("Client ID", text: $settings.customClientId)

--- a/UpThere/Views/SettingsView.swift
+++ b/UpThere/Views/SettingsView.swift
@@ -137,30 +137,6 @@ struct SettingsView: View {
                 }
             }
         }
-
-        Section("AviationStack API") {
-            SecureField("API Key", text: $settings.aviationStackApiKey)
-                #if os(iOS)
-                .textInputAutocapitalization(.never)
-                #endif
-                .autocorrectionDisabled()
-
-            VStack(alignment: .leading, spacing: 4) {
-                Label("Overrides environment variables", systemImage: "info.circle")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                Link("Get API key at aviationstack.com",
-                     destination: URL(string: "https://aviationstack.com/")!)
-                    .font(.caption)
-            }
-            .padding(.top, 2)
-
-            if !settings.aviationStackApiKey.isEmpty {
-                Button("Clear API Key", role: .destructive) {
-                    settings.aviationStackApiKey = ""
-                }
-            }
-        }
     }
 
     // MARK: - AviationStack API

--- a/UpThere/Views/SettingsView.swift
+++ b/UpThere/Views/SettingsView.swift
@@ -11,6 +11,7 @@ struct SettingsView: View {
                 searchRadiusSection
                 refreshIntervalSection
                 mapStyleSection
+                unitsSection
                 apiCredentialsSection
             }
             #if os(macOS)
@@ -85,6 +86,23 @@ struct SettingsView: View {
                 }
             }
             .pickerStyle(.segmented)
+        }
+    }
+
+    // MARK: - Unit Preferences
+
+    private var unitsSection: some View {
+        Section("Units") {
+            Picker("Altitude", selection: $settings.altitudeUnit) {
+                ForEach(AltitudeUnit.allCases) { unit in
+                    Text(unit.displayName).tag(unit)
+                }
+            }
+            Picker("Speed", selection: $settings.speedUnit) {
+                ForEach(SpeedUnit.allCases) { unit in
+                    Text(unit.displayName).tag(unit)
+                }
+            }
         }
     }
 

--- a/UpThere/Views/SettingsView.swift
+++ b/UpThere/Views/SettingsView.swift
@@ -136,6 +136,30 @@ struct SettingsView: View {
                 }
             }
         }
+
+        Section("AviationStack API") {
+            SecureField("API Key", text: $settings.aviationStackApiKey)
+                #if os(iOS)
+                .textInputAutocapitalization(.never)
+                #endif
+                .autocorrectionDisabled()
+
+            VStack(alignment: .leading, spacing: 4) {
+                Label("Overrides environment variables", systemImage: "info.circle")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                Link("Get API key at aviationstack.com",
+                     destination: URL(string: "https://aviationstack.com/")!)
+                    .font(.caption)
+            }
+            .padding(.top, 2)
+
+            if !settings.aviationStackApiKey.isEmpty {
+                Button("Clear API Key", role: .destructive) {
+                    settings.aviationStackApiKey = ""
+                }
+            }
+        }
     }
 
     // MARK: - AviationStack API

--- a/UpThereTests/AppSettingsTests.swift
+++ b/UpThereTests/AppSettingsTests.swift
@@ -1,0 +1,158 @@
+import Foundation
+import Testing
+
+@testable import UpThere
+
+@MainActor
+struct AppSettingsTests {
+
+    // MARK: - Defaults
+
+    @Test
+    func testDefaultSearchRadius() {
+        let settings = AppSettings()
+        #expect(settings.searchRadius == .twoHundred)
+    }
+
+    @Test
+    func testDefaultRefreshOption() {
+        let settings = AppSettings()
+        #expect(settings.refreshOption == .often)
+    }
+
+    @Test
+    func testDefaultMapStyle() {
+        let settings = AppSettings()
+        #expect(settings.mapStyle == .standard)
+    }
+
+    @Test
+    func testDefaultCredentialsEmpty() {
+        let settings = AppSettings()
+        #expect(settings.customClientId.isEmpty)
+        #expect(settings.customClientSecret.isEmpty)
+        #expect(!settings.hasCustomCredentials)
+    }
+
+    // MARK: - Effective Refresh Interval
+
+    @Test
+    func testEffectiveRefreshInterval_presets() {
+        let settings = AppSettings()
+
+        settings.refreshOption = .often
+        #expect(settings.effectiveRefreshInterval == 5)
+
+        settings.refreshOption = .medium
+        #expect(settings.effectiveRefreshInterval == 30)
+
+        settings.refreshOption = .seldom
+        #expect(settings.effectiveRefreshInterval == 60)
+    }
+
+    @Test
+    func testEffectiveRefreshInterval_manual() {
+        let settings = AppSettings()
+        settings.refreshOption = .manual
+        #expect(settings.effectiveRefreshInterval == nil)
+    }
+
+    @Test
+    func testEffectiveRefreshInterval_custom() {
+        let settings = AppSettings()
+        settings.refreshOption = .custom
+        settings.customRefreshSeconds = 15
+        #expect(settings.effectiveRefreshInterval == 15)
+    }
+
+    @Test
+    func testEffectiveRefreshInterval_custom_minimum() {
+        let settings = AppSettings()
+        settings.refreshOption = .custom
+        settings.customRefreshSeconds = 0.5
+        #expect(settings.effectiveRefreshInterval == 1)
+    }
+
+    // MARK: - Persistence
+
+    @Test
+    func testSearchRadiusPersistence() {
+        let settings = AppSettings()
+        settings.searchRadius = .fiveHundred
+        #expect(settings.searchRadius == .fiveHundred)
+
+        let fresh = AppSettings()
+        #expect(fresh.searchRadius == .fiveHundred)
+
+        UserDefaults.standard.removeObject(forKey: "upthere.searchRadius")
+    }
+
+    @Test
+    func testRefreshOptionPersistence() {
+        let settings = AppSettings()
+        settings.refreshOption = .seldom
+        #expect(settings.refreshOption == .seldom)
+
+        let fresh = AppSettings()
+        #expect(fresh.refreshOption == .seldom)
+
+        UserDefaults.standard.removeObject(forKey: "upthere.refreshOption")
+    }
+
+    @Test
+    func testMapStylePersistence() {
+        let settings = AppSettings()
+        settings.mapStyle = .hybrid
+        #expect(settings.mapStyle == .hybrid)
+
+        let fresh = AppSettings()
+        #expect(fresh.mapStyle == .hybrid)
+
+        UserDefaults.standard.removeObject(forKey: "upthere.mapStyle")
+    }
+
+    @Test
+    func testCredentialsPersistence() {
+        let settings = AppSettings()
+        settings.customClientId = "my-id"
+        settings.customClientSecret = "my-secret"
+        #expect(settings.hasCustomCredentials)
+
+        let fresh = AppSettings()
+        #expect(fresh.customClientId == "my-id")
+        #expect(fresh.customClientSecret == "my-secret")
+        #expect(fresh.hasCustomCredentials)
+
+        UserDefaults.standard.removeObject(forKey: "upthere.customClientId")
+        UserDefaults.standard.removeObject(forKey: "upthere.customClientSecret")
+    }
+
+    // MARK: - Enum Cases
+
+    @Test
+    func testSearchRadiusCases() {
+        #expect(SearchRadius.allCases.count == 4)
+        #expect(SearchRadius.fifty.displayName == "50 km")
+        #expect(SearchRadius.oneHundred.displayName == "100 km")
+        #expect(SearchRadius.twoHundred.displayName == "200 km")
+        #expect(SearchRadius.fiveHundred.displayName == "500 km")
+    }
+
+    @Test
+    func testRefreshIntervalOptionCases() {
+        #expect(RefreshIntervalOption.allCases.count == 5)
+        #expect(RefreshIntervalOption.often.presetSeconds == 5)
+        #expect(RefreshIntervalOption.medium.presetSeconds == 30)
+        #expect(RefreshIntervalOption.seldom.presetSeconds == 60)
+        #expect(RefreshIntervalOption.manual.presetSeconds == nil)
+        #expect(RefreshIntervalOption.custom.presetSeconds == nil)
+    }
+
+    @Test
+    func testAppMapStyleCases() {
+        #expect(AppMapStyle.allCases.count == 3)
+        #expect(AppMapStyle.standard.displayName == "Standard")
+        #expect(AppMapStyle.satellite.displayName == "Satellite")
+        #expect(AppMapStyle.hybrid.displayName == "Hybrid")
+    }
+}

--- a/UpThereTests/AppSettingsTests.swift
+++ b/UpThereTests/AppSettingsTests.swift
@@ -155,4 +155,62 @@ struct AppSettingsTests {
         #expect(AppMapStyle.satellite.displayName == "Satellite")
         #expect(AppMapStyle.hybrid.displayName == "Hybrid")
     }
+
+    // MARK: - Unit Preference Defaults
+
+    @Test
+    func testDefaultAltitudeUnit() {
+        let settings = AppSettings()
+        #expect(settings.altitudeUnit == .meters)
+    }
+
+    @Test
+    func testDefaultSpeedUnit() {
+        let settings = AppSettings()
+        #expect(settings.speedUnit == .kmh)
+    }
+
+    @Test
+    func testAltitudeUnitPersistence() {
+        let settings = AppSettings()
+        settings.altitudeUnit = .feet
+        #expect(settings.altitudeUnit == .feet)
+
+        let fresh = AppSettings()
+        #expect(fresh.altitudeUnit == .feet)
+
+        UserDefaults.standard.removeObject(forKey: "upthere.altitudeUnit")
+    }
+
+    @Test
+    func testSpeedUnitPersistence() {
+        let settings = AppSettings()
+        settings.speedUnit = .knots
+        #expect(settings.speedUnit == .knots)
+
+        let fresh = AppSettings()
+        #expect(fresh.speedUnit == .knots)
+
+        UserDefaults.standard.removeObject(forKey: "upthere.speedUnit")
+    }
+
+    // MARK: - Unit Enum Cases
+
+    @Test
+    func testAltitudeUnitCases() {
+        #expect(AltitudeUnit.allCases.count == 2)
+        #expect(AltitudeUnit.meters.displayName == "Meters (m)")
+        #expect(AltitudeUnit.feet.displayName == "Feet (ft)")
+        #expect(AltitudeUnit.meters.symbol == "m")
+        #expect(AltitudeUnit.feet.symbol == "ft")
+    }
+
+    @Test
+    func testSpeedUnitCases() {
+        #expect(SpeedUnit.allCases.count == 2)
+        #expect(SpeedUnit.kmh.displayName == "km/h")
+        #expect(SpeedUnit.knots.displayName == "Knots (kt)")
+        #expect(SpeedUnit.kmh.symbol == "km/h")
+        #expect(SpeedUnit.knots.symbol == "kt")
+    }
 }

--- a/UpThereTests/FlightServiceTests.swift
+++ b/UpThereTests/FlightServiceTests.swift
@@ -23,6 +23,15 @@ struct FlightServiceTests {
         return URLSession(configuration: configuration)
     }
     
+    /// Creates test credentials with the given client ID and secret
+    private func makeCredentials(clientId: String, clientSecret: String) -> ResolvedCredentials {
+        ResolvedCredentials(
+            clientId: clientId,
+            clientSecret: clientSecret,
+            sourceDescription: "test"
+        )
+    }
+    
     // MARK: - Successful API Calls
     
     @Test
@@ -42,8 +51,8 @@ struct FlightServiceTests {
             }
         }
         
-        let config = OpenSkyConfig(clientId: "test", clientSecret: "test")
-        let service = FlightService(config: config, session: session)
+        let credentials = makeCredentials(clientId: "test", clientSecret: "test")
+        let service = FlightService(credentials: credentials, session: session)
         
         let flights = try await service.fetchFlights(in: boundingBox)
         
@@ -68,8 +77,8 @@ struct FlightServiceTests {
             }
         }
         
-        let config = OpenSkyConfig(clientId: "test", clientSecret: "test")
-        let service = FlightService(config: config, session: session)
+        let credentials = makeCredentials(clientId: "test", clientSecret: "test")
+        let service = FlightService(credentials: credentials, session: session)
         
         let flights = try await service.fetchFlights(in: boundingBox)
         
@@ -91,8 +100,8 @@ struct FlightServiceTests {
             }
         }
         
-        let config = OpenSkyConfig(clientId: "test", clientSecret: "test")
-        let service = FlightService(config: config, session: session)
+        let credentials = makeCredentials(clientId: "test", clientSecret: "test")
+        let service = FlightService(credentials: credentials, session: session)
         
         let flights = try await service.fetchFlights(in: boundingBox)
         
@@ -116,8 +125,8 @@ struct FlightServiceTests {
             }
         }
         
-        let config = OpenSkyConfig(clientId: "test", clientSecret: "test")
-        let service = FlightService(config: config, session: session)
+        let credentials = makeCredentials(clientId: "test", clientSecret: "test")
+        let service = FlightService(credentials: credentials, session: session)
         
         do {
             _ = try await service.fetchFlights(in: boundingBox)
@@ -134,8 +143,8 @@ struct FlightServiceTests {
             return (response, "Unauthorized".data(using: .utf8)!)
         }
         
-        let config = OpenSkyConfig(clientId: "test", clientSecret: "test")
-        let service = FlightService(config: config, session: session)
+        let credentials = makeCredentials(clientId: "test", clientSecret: "test")
+        let service = FlightService(credentials: credentials, session: session)
         
         do {
             _ = try await service.fetchFlights(in: boundingBox)
@@ -160,8 +169,8 @@ struct FlightServiceTests {
             }
         }
         
-        let config = OpenSkyConfig(clientId: "test", clientSecret: "test")
-        let service = FlightService(config: config, session: session)
+        let credentials = makeCredentials(clientId: "test", clientSecret: "test")
+        let service = FlightService(credentials: credentials, session: session)
         
         do {
             _ = try await service.fetchFlights(in: boundingBox)
@@ -180,8 +189,8 @@ struct FlightServiceTests {
             throw networkError
         }
         
-        let config = OpenSkyConfig(clientId: "test", clientSecret: "test")
-        let service = FlightService(config: config, session: session)
+        let credentials = makeCredentials(clientId: "test", clientSecret: "test")
+        let service = FlightService(credentials: credentials, session: session)
         
         do {
             _ = try await service.fetchFlights(in: boundingBox)
@@ -220,8 +229,8 @@ struct FlightServiceTests {
             }
         }
         
-        let config = OpenSkyConfig(clientId: "test", clientSecret: "test")
-        let service = FlightService(config: config, session: session)
+        let credentials = makeCredentials(clientId: "test", clientSecret: "test")
+        let service = FlightService(credentials: credentials, session: session)
         
         let positions = try await service.fetchFlightHistory(icao24: "3c6444", timeFrom: 1704063600, timeTo: 1704067200)
         
@@ -246,8 +255,8 @@ struct FlightServiceTests {
             }
         }
         
-        let config = OpenSkyConfig(clientId: "test", clientSecret: "test")
-        let service = FlightService(config: config, session: session)
+        let credentials = makeCredentials(clientId: "test", clientSecret: "test")
+        let service = FlightService(credentials: credentials, session: session)
         
         let positions = try await service.fetchFlightHistory(icao24: "3c6444", timeFrom: 1704063600, timeTo: 1704067200)
         
@@ -269,8 +278,8 @@ struct FlightServiceTests {
             }
         }
         
-        let config = OpenSkyConfig(clientId: "test", clientSecret: "test")
-        let service = FlightService(config: config, session: session)
+        let credentials = makeCredentials(clientId: "test", clientSecret: "test")
+        let service = FlightService(credentials: credentials, session: session)
         
         do {
             _ = try await service.fetchFlightHistory(icao24: "3c6444", timeFrom: 1704063600, timeTo: 1704067200)

--- a/UpThereTests/FlightTests.swift
+++ b/UpThereTests/FlightTests.swift
@@ -122,6 +122,24 @@ struct FlightTests {
     }
     
     @Test
+    func testSpeedKmhConversion() {
+        let state = createValidState(velocity: 250.5) // m/s
+        let flight = Flight(from: state, lastUpdate: Date())!
+        
+        // 250.5 m/s * 3.6 = 901.8 km/h
+        #expect(flight.speedKmh != nil)
+        #expect(abs(flight.speedKmh! - 901.8) < 0.1)
+    }
+    
+    @Test
+    func testSpeedKmhReturnsNilWhenNoVelocity() {
+        let state = createValidState(velocity: nil)
+        let flight = Flight(from: state, lastUpdate: Date())!
+        
+        #expect(flight.speedKmh == nil)
+    }
+    
+    @Test
     func testVerticalRateFPMConversion() {
         let state = createValidState(verticalRate: 5.0) // m/s
         let flight = Flight(from: state, lastUpdate: Date())!


### PR DESCRIPTION
## Summary
- **Settings Panel**: New `SettingsView` with configuration for search radius, auto-refresh interval, map style, and custom API credentials
- **Persistence**: `AppSettings` model backed by `UserDefaults` — settings survive app restarts, dev rebuilds, and App Store updates
- **Credential Resolution**: FlightService resolves credentials with priority: custom settings → environment variables → unauthenticated, with clear logging of which source is used
- **Reactive Updates**: Changing settings (radius, interval, credentials) takes effect immediately without app restart
- **Tests**: 15 new `AppSettingsTests` covering defaults, persistence, and enum cases; all 76 tests pass on both iOS and macOS

## Settings
| Setting | Options |
|---------|---------|
| Search Radius | 50km, 100km, 200km, 500km |
| Refresh Interval | Often (5s), Medium (30s), Seldom (60s), Manual, Custom (seconds) |
| Map Style | Standard, Satellite, Hybrid |
| API Credentials | Client ID + Client Secret (overrides env vars) |

## Files Changed
- **New**: `AppSettings.swift`, `SettingsView.swift`, `AppSettingsTests.swift`
- **Modified**: `FlightService.swift`, `OpenSkyConfig.swift`, `UpThereViewModel.swift`, `ContentView.swift`, `FlightMapView.swift`, `UpThereApp.swift`, `FlightServiceTests.swift`

Closes #1