### PR TITLE
✨ Add flight trails and flight selection system

### DIFF
--- a/Requirements/README.md
+++ b/Requirements/README.md
@@ -83,6 +83,7 @@ Scenarios are structured for future automated UI test generation. Each scenario 
 | [SYSREQ-004](core/SYSREQ-004-auto-refresh.md) | Auto-Refresh | medium | implemented |
 | [SYSREQ-005](core/SYSREQ-005-manual-refresh.md) | Manual Refresh | medium | implemented |
 | [SYSREQ-006](core/SYSREQ-006-error-handling.md) | Error Handling | medium | implemented |
+| [SYSREQ-007](core/SYSREQ-007-flight-trails.md) | Flight Trails | medium | implemented |
 
 ### User Interface Requirements (UIREQ-*)
 
@@ -92,6 +93,7 @@ Scenarios are structured for future automated UI test generation. Each scenario 
 | [UIREQ-002](ui/UIREQ-002-flight-map-view.md) | Flight Map View | high | implemented |
 | [UIREQ-003](ui/UIREQ-003-flight-detail-view.md) | Flight Detail View | medium | implemented |
 | [UIREQ-004](ui/UIREQ-004-adaptive-layout.md) | Adaptive Layout | medium | implemented |
+| [UIREQ-005](ui/UIREQ-005-flight-selection.md) | Flight Selection | high | implemented |
 
 ### Non-Functional Requirements (NFREQ-*)
 

--- a/Requirements/core/SYSREQ-007-flight-trails.md
+++ b/Requirements/core/SYSREQ-007-flight-trails.md
@@ -1,0 +1,112 @@
+---
+id: SYSREQ-007
+title: Flight Trails
+priority: medium
+type: feature
+status: implemented
+tags: [core, map, trails, history, api]
+scenarios:
+  - id: SC-SYSREQ-007-01
+    name: Accumulate trail positions on each refresh
+    given: The app is tracking flights and a flight is visible on the map
+    when: A new flight position is received during auto-refresh
+    then: The position is appended to that flight's trail and old positions beyond 5 minutes are trimmed
+  - id: SC-SYSREQ-007-02
+    name: Fetch complete historical trail for selected flight
+    given: A flight is selected and the OpenSky API is reachable
+    when: The flight is selected
+    then: The complete historical flight path is fetched from the API and displayed
+  - id: SC-SYSREQ-007-03
+    name: Expire trails for flights no longer in view
+    given: A flight was visible but is no longer returned by the API
+    when: The trail's most recent position is older than 5 minutes
+    then: The trail is removed from the trails dictionary
+  - id: SC-SYSREQ-007-04
+    name: Clear trails when stopping tracking
+    given: The app is tracking flights with accumulated trails
+    when: The user stops tracking
+    then: All trails and the selected flight trail are cleared
+  - id: SC-SYSREQ-007-05
+    name: Fall back to accumulated trail if API fails
+    given: A flight is selected but the historical API request fails
+    when: The API returns an error
+    then: The accumulated client-side trail is used as a fallback
+  - id: SC-SYSREQ-007-06
+    name: Trim trail to 5-minute window
+    given: A flight has accumulated positions over multiple refresh cycles
+    when: A new position is added that makes older positions exceed 5 minutes
+    then: Positions older than 5 minutes from the most recent are removed
+---
+
+# SYSREQ-007: Flight Trails
+
+## Description
+
+The application displays recent flight paths/trajectories on the map for each aircraft. Trails are built using a hybrid approach:
+
+1. **Accumulated trails (client-side)**: For all visible flights, positions are accumulated from each 5-second refresh cycle. Only the last 5 minutes of positions are kept.
+2. **Complete historical trail (API)**: When a flight is selected, the full historical path is fetched from the OpenSky Network API (`/api/states/all` endpoint with `icao24`, `time`, and `endTime` parameters).
+
+This approach minimizes API calls — no extra calls are needed for regular trails, and only one call is made when a flight is selected.
+
+## Source Files
+
+- `UpThere/Models/FlightTrail.swift` — Trail data model
+- `UpThere/Models/OpenSkyResponse.swift` — `OpenSkyHistoryResponse` parsing
+- `UpThere/Services/FlightService.swift` — `fetchFlightHistory(icao24:timeFrom:timeTo:)` method
+- `UpThere/ViewModels/UpThereViewModel.swift` — Trail accumulation, `selectedFlightTrail`, `fetchSelectedFlightTrail()`
+
+## Acceptance Criteria
+
+1. A `FlightTrail` model stores ordered timestamped positions per ICAO24 identifier
+2. Trails accumulate positions on each `refreshFlights()` call without additional API calls
+3. Accumulated trails are trimmed to a rolling 5-minute window
+4. Trails for flights no longer in view are expired after 5 minutes
+5. Selecting a flight triggers a single API call to fetch complete historical data (last 24 hours)
+6. If the API call fails, the accumulated trail is used as a fallback
+7. All trails are cleared when tracking is stopped
+8. The `OpenSkyHistoryResponse` is parsed from the same raw array format as the live states endpoint
+9. The `FlightService.fetchFlightHistory` method handles auth, token refresh, rate limiting, and errors
+
+## FlightTrail Model
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `id` | `String` | ICAO24 identifier (same as `Flight.id`) |
+| `positions` | `[(date: Date, coordinate: CLLocationCoordinate2D)]` | Ordered timestamped positions (oldest first) |
+| `isCompleteHistory` | `Bool` | Whether this trail was fetched from the API |
+| `coordinates` | `[CLLocationCoordinate2D]` | Array of coordinates for MapKit polyline rendering |
+| `isValid` | `Bool` | True if at least 2 positions exist |
+| `positionCount` | `Int` | Number of positions in the trail |
+| `coordinateRegion` | `MKCoordinateRegion?` | Region encompassing all positions with 20% padding |
+
+### Methods
+
+| Method | Description |
+|--------|-------------|
+| `append(date:coordinate:)` | Add a position; auto-trims if not complete history |
+| `setCompleteHistory(positions:)` | Replace trail with API data; disables auto-trimming |
+| `resetToAccumulated()` | Re-enable auto-trimming and trim to 5-minute window |
+
+## Trail Rendering
+
+| Trail Type | Color | Line Width | Source |
+|------------|-------|------------|--------|
+| Accumulated (non-selected) | Orange 35% opacity | 1.5pt | Client-side accumulation |
+| Accumulated (selected) | Orange 100% opacity | 2.5pt | Client-side accumulation |
+| Complete history | Orange 100% opacity | 3.0pt | API fetch |
+
+## OpenSky History API
+
+- Endpoint: `GET /api/states/all?icao24={id}&time={from}&endTime={to}`
+- Returns the same array format as `/states/all`
+- Requires authentication (OAuth2 Bearer token)
+- Subject to rate limiting (429)
+- Time range: up to 24 hours for free tier
+
+## Edge Cases
+
+- Positions with invalid coordinates (outside -90/90 lat, -180/180 lon) are filtered out
+- Duplicate positions at the same timestamp are skipped
+- Empty history responses return an empty positions array
+- Token expiration during history fetch triggers automatic refresh and retry

--- a/Requirements/ui/UIREQ-005-flight-selection.md
+++ b/Requirements/ui/UIREQ-005-flight-selection.md
@@ -1,0 +1,114 @@
+---
+id: UIREQ-005
+title: Flight Selection
+priority: high
+type: feature
+status: implemented
+tags: [ui, map, list, selection, interaction]
+scenarios:
+  - id: SC-UIREQ-005-01
+    name: Select a flight by tapping on the map
+    given: The map view displays one or more flight markers
+    when: The user taps a flight marker
+    then: The flight is selected, highlighted on the map, and its complete trail is fetched
+  - id: SC-UIREQ-005-02
+    name: Select a flight by tapping in the list
+    given: The flight list displays one or more flights
+    when: The user taps a flight row
+    then: The flight is selected and highlighted in both the list and the map
+  - id: SC-UIREQ-005-03
+    name: Deselect by tapping the same flight
+    given: A flight is currently selected
+    when: The user taps the same flight again (in list or map)
+    then: The flight is deselected and the complete trail is hidden
+  - id: SC-UIREQ-005-04
+    name: Deselect by tapping empty map space
+    given: A flight is currently selected
+    when: The user taps an empty area on the map
+    then: The flight is deselected and the complete trail is hidden
+  - id: SC-UIREQ-005-05
+    name: Switch selection to another flight
+    given: Flight A is currently selected
+    when: The user taps Flight B (in list or map)
+    then: Flight A is deselected, Flight B is selected and its complete trail is fetched
+  - id: SC-UIREQ-005-06
+    name: Open detail view for selected flight
+    given: A flight is currently selected
+    when: The user taps the info button
+    then: The flight detail sheet opens showing the trail map and flight information
+  - id: SC-UIREQ-005-07
+    name: Selection syncs across list and map
+    given: A flight is selected from the map view
+    when: The user switches to the list view (or uses split view on iPad)
+    then: The same flight is highlighted in the list with a checkmark and info button
+---
+
+# UIREQ-005: Flight Selection
+
+## Description
+
+The application provides a unified flight selection mechanism that works across the map view, list view, and split view (iPad/Mac). Selecting a flight highlights it everywhere and triggers fetching of its complete historical trail. Deselection is possible through multiple intuitive interactions.
+
+## Source Files
+
+- `UpThere/Views/ContentView.swift` — Central selection wiring, detail sheet management
+- `UpThere/Views/FlightMapView.swift` — Map annotation tap, map background tap, floating detail button
+- `UpThere/Views/FlightListView.swift` — Row tap, checkmark indicator, detail button, row highlight
+- `UpThere/ViewModels/UpThereViewModel.swift` — `selectedFlight`, `selectFlight(_:)` with toggle logic
+
+## Acceptance Criteria
+
+1. Tapping a flight marker on the map selects it
+2. Tapping a flight row in the list selects it
+3. Tapping the same flight again deselects it (toggle behavior)
+4. Tapping empty space on the map deselects the current flight
+5. Selecting a different flight switches selection (old deselects, new selects)
+6. Selection is synchronized across all views (map, list, split view)
+7. The selected flight is visually highlighted in both the map and list
+8. A floating "Details" button appears on the map when a flight is selected
+9. An "Info" button appears in the list row for the selected flight
+10. Opening the detail sheet shows the complete trail map and flight information
+11. Selection state is cleared when tracking is stopped
+
+## Visual Design
+
+### Map View
+
+| Element | Unselected | Selected |
+|---------|------------|----------|
+| Marker | Orange airplane, white circle, gray stroke | Orange airplane, orange-tinted circle, orange stroke (3pt) |
+| Trail | Dim orange polyline (35% opacity, 1.5pt) | Bright orange complete trail (100% opacity, 3.0pt) |
+| Detail button | Hidden | Floating `info.circle` button below refresh button |
+
+### List View
+
+| Element | Unselected | Selected |
+|---------|------------|----------|
+| Row background | Default | Orange 10% opacity |
+| Left indicators | None | `info.circle` button + `checkmark.circle.fill` icon |
+| Row content | Standard | Same content, highlighted background |
+
+## Interaction Flow
+
+```
+User taps flight (map or list)
+  → viewModel.selectFlight(flight)
+    → If same flight: deselect (toggle off)
+    → If different flight: deselect old, select new, fetch trail
+    → UI updates: highlights, trails, buttons
+
+User taps empty map space
+  → viewModel.selectFlight(nil)
+    → Deselect current flight, hide trail
+
+User taps info button
+  → showDetail = true
+    → Sheet opens with FlightDetailView
+```
+
+## Edge Cases
+
+- If the historical API call fails, the accumulated trail is still shown
+- Rapid selection/deselection is handled gracefully by the ViewModel's toggle logic
+- Selection is cleared when the app stops tracking (trails dictionary is emptied)
+- On iPad split view, selecting in the list automatically highlights on the map and vice versa

--- a/UpThere/Models/FlightTrail.swift
+++ b/UpThere/Models/FlightTrail.swift
@@ -1,0 +1,99 @@
+import Foundation
+import CoreLocation
+import MapKit
+
+/// Represents the recent flight path/trajectory for a single aircraft.
+///
+/// Trails are built client-side by accumulating positions from each 5-second refresh.
+/// For non-selected flights, only the last 5 minutes of positions are kept.
+/// For the selected flight, a complete historical trail is fetched from the API.
+struct FlightTrail: Identifiable {
+    /// ICAO24 identifier (same as Flight.id)
+    let id: String
+    
+    /// Ordered list of timestamped positions (oldest first)
+    private(set) var positions: [(date: Date, coordinate: CLLocationCoordinate2D)] = []
+    
+    /// Whether this trail was fetched from the historical API (complete flight)
+    var isCompleteHistory: Bool = false
+    
+    /// Maximum age of positions to keep for accumulated trails
+    static let maxTrailAge: TimeInterval = 5 * 60 // 5 minutes
+    
+    /// Create a new trail for the given ICAO24
+    init(icao24: String) {
+        self.id = icao24
+    }
+    
+    /// Append a new position to the trail.
+    /// Automatically trims positions older than 5 minutes (unless this is a complete history trail).
+    mutating func append(date: Date, coordinate: CLLocationCoordinate2D) {
+        // Don't add duplicate positions at the same timestamp
+        if let last = positions.last, last.date == date {
+            return
+        }
+        positions.append((date: date, coordinate: coordinate))
+        // Keep sorted by date
+        positions.sort { $0.date < $1.date }
+        if !isCompleteHistory {
+            trimToMaxAge()
+        }
+    }
+    
+    /// Trim positions older than maxTrailAge from the most recent position.
+    private mutating func trimToMaxAge() {
+        guard let mostRecent = positions.map(\.date).max() else { return }
+        let cutoff = mostRecent.addingTimeInterval(-Self.maxTrailAge)
+        positions.removeAll { $0.date < cutoff }
+    }
+    
+    /// Replace the entire trail with positions from the historical API.
+    mutating func setCompleteHistory(positions: [(date: Date, coordinate: CLLocationCoordinate2D)]) {
+        self.positions = positions.sorted { $0.date < $1.date }
+        self.isCompleteHistory = true
+    }
+    
+    /// Reset to an accumulated trail (e.g., when deselecting a flight).
+    mutating func resetToAccumulated() {
+        isCompleteHistory = false
+        trimToMaxAge()
+    }
+    
+    /// Array of CLLocationCoordinate2D for MapKit polyline rendering
+    var coordinates: [CLLocationCoordinate2D] {
+        positions.map(\.coordinate)
+    }
+    
+    /// Whether the trail has enough points to render (minimum 2)
+    var isValid: Bool {
+        positions.count >= 2
+    }
+    
+    /// Number of positions in the trail
+    var positionCount: Int {
+        positions.count
+    }
+    
+    /// MKCoordinateRegion that encompasses all positions in the trail
+    var coordinateRegion: MKCoordinateRegion? {
+        guard !positions.isEmpty else { return nil }
+        
+        let coords = positions.map(\.coordinate)
+        let minLat = coords.map(\.latitude).min()!
+        let maxLat = coords.map(\.latitude).max()!
+        let minLon = coords.map(\.longitude).min()!
+        let maxLon = coords.map(\.longitude).max()!
+        
+        let centerLat = (minLat + maxLat) / 2
+        let centerLon = (minLon + maxLon) / 2
+        
+        // Add 20% padding
+        let latDelta = max((maxLat - minLat) * 1.2, 0.01)
+        let lonDelta = max((maxLon - minLon) * 1.2, 0.01)
+        
+        return MKCoordinateRegion(
+            center: CLLocationCoordinate2D(latitude: centerLat, longitude: centerLon),
+            span: MKCoordinateSpan(latitudeDelta: latDelta, longitudeDelta: lonDelta)
+        )
+    }
+}

--- a/UpThere/Models/OpenSkyResponse.swift
+++ b/UpThere/Models/OpenSkyResponse.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Response from OpenSky Network states/all endpoint
+/// Response from OpenSky Network states/all endpoint (also used for historical queries)
 /// Note: We parse this manually since the states array contains mixed types
 struct OpenSkyResponse {
     /// Unix timestamp of the request
@@ -61,6 +61,64 @@ enum OpenSkyError: Error, LocalizedError {
         case .rateLimited:
             return "OpenSky rate limit exceeded"
         }
+    }
+}
+
+/// Response from OpenSky Network historical states endpoint
+/// The response has the same shape as the live states endpoint: { time: Int, states: [[Any]] }
+struct OpenSkyHistoryResponse {
+    /// Unix timestamp of the request
+    let time: Int
+    
+    /// Raw states array from JSON
+    let states: [[Any]]?
+    
+    /// Convert to array of (date, longitude, latitude) tuples
+    func toPositions() -> [(date: Date, longitude: Double, latitude: Double)] {
+        guard let states = states else { return [] }
+        
+        return states.compactMap { state -> (date: Date, longitude: Double, latitude: Double)? in
+            guard state.count >= 7,
+                  let lon = state[5] as? Double,
+                  let lat = state[6] as? Double else {
+                return nil
+            }
+            
+            // time_position is at index 3
+            if let timePosition = state[3] as? Int {
+                return (
+                    date: Date(timeIntervalSince1970: TimeInterval(timePosition)),
+                    longitude: lon,
+                    latitude: lat
+                )
+            }
+            
+            // Fall back to last_contact at index 4
+            if let lastContact = state[4] as? Int {
+                return (
+                    date: Date(timeIntervalSince1970: TimeInterval(lastContact)),
+                    longitude: lon,
+                    latitude: lat
+                )
+            }
+            
+            return nil
+        }
+    }
+    
+    /// Parse from JSON data
+    static func parse(from data: Data) throws -> OpenSkyHistoryResponse {
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let time = json["time"] as? Int else {
+            throw OpenSkyError.invalidResponse
+        }
+        
+        var states: [[Any]]? = nil
+        if let rawStates = json["states"] as? [[Any]] {
+            states = rawStates
+        }
+        
+        return OpenSkyHistoryResponse(time: time, states: states)
     }
 }
 

--- a/UpThere/Services/FlightService.swift
+++ b/UpThere/Services/FlightService.swift
@@ -173,15 +173,116 @@ actor FlightService {
         return accessToken
     }
     
+    /// Fetch historical flight states for a specific aircraft.
+    /// Returns an array of (timestamp, longitude, latitude) tuples.
+    /// - Parameters:
+    ///   - icao24: The ICAO24 hex identifier of the aircraft
+    ///   - timeFrom: Start of the time range (Unix timestamp)
+    ///   - timeTo: End of the time range (Unix timestamp)
+    /// - Returns: Array of (date, longitude, latitude) tuples sorted by time
+    func fetchFlightHistory(icao24: String, timeFrom: Int, timeTo: Int) async throws -> [(date: Date, longitude: Double, latitude: Double)] {
+        let url = try buildHistoryURL(icao24: icao24, timeFrom: timeFrom, timeTo: timeTo)
+        AppLogger.flightService.debug("Fetching flight history for \(icao24, privacy: .public) from \(timeFrom, privacy: .public) to \(timeTo, privacy: .public)")
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+
+        if config.isConfigured {
+            let token = try await getAccessToken()
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        do {
+            let (data, response) = try await session.data(for: request)
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                AppLogger.flightService.error("Invalid response type from OpenSky history API")
+                throw OpenSkyError.invalidResponse
+            }
+
+            switch httpResponse.statusCode {
+            case 200:
+                let historyResponse = try OpenSkyHistoryResponse.parse(from: data)
+                let positions = historyResponse.toPositions()
+                AppLogger.flightService.debug("Fetched \(positions.count, privacy: .public) historical positions for \(icao24, privacy: .public)")
+                return positions
+            case 401:
+                AppLogger.flightService.warning("Received 401 from history API, refreshing token and retrying")
+                accessToken = nil
+                tokenExpiresAt = nil
+                if config.isConfigured {
+                    let newToken = try await getAccessToken()
+                    return try await fetchFlightHistoryWithToken(newToken, icao24: icao24, timeFrom: timeFrom, timeTo: timeTo)
+                }
+                throw OpenSkyError.unauthorized
+            case 429:
+                AppLogger.flightService.warning("Rate limited by OpenSky history API (429)")
+                throw OpenSkyError.rateLimited
+            default:
+                if let errorText = String(data: data, encoding: .utf8), !errorText.isEmpty {
+                    AppLogger.flightService.error("OpenSky history API error (\(httpResponse.statusCode, privacy: .public)): \(errorText, privacy: .public)")
+                }
+                throw OpenSkyError.invalidResponse
+            }
+        } catch let error as OpenSkyError {
+            throw error
+        } catch {
+            AppLogger.flightService.error("Network error fetching flight history: \(error.localizedDescription, privacy: .public)")
+            throw OpenSkyError.networkError(error)
+        }
+    }
+
+    /// Fetch flight history with a specific token (retry after 401)
+    private func fetchFlightHistoryWithToken(_ token: String, icao24: String, timeFrom: Int, timeTo: Int) async throws -> [(date: Date, longitude: Double, latitude: Double)] {
+        let url = try buildHistoryURL(icao24: icao24, timeFrom: timeFrom, timeTo: timeTo)
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+
+        let (data, response) = try await session.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            AppLogger.flightService.error("Invalid response type from OpenSky history API (retry)")
+            throw OpenSkyError.invalidResponse
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            if let errorText = String(data: data, encoding: .utf8), !errorText.isEmpty {
+                AppLogger.flightService.error("OpenSky history API error after token refresh (\(httpResponse.statusCode, privacy: .public)): \(errorText, privacy: .public)")
+            }
+            throw OpenSkyError.invalidResponse
+        }
+
+        let historyResponse = try OpenSkyHistoryResponse.parse(from: data)
+        let positions = historyResponse.toPositions()
+        AppLogger.flightService.debug("Fetched \(positions.count, privacy: .public) historical positions for \(icao24, privacy: .public) (after token refresh)")
+        return positions
+    }
+
     /// Build URL with query parameters
     private func buildURL(for boundingBox: BoundingBox) throws -> URL {
         var components = URLComponents(string: "\(config.baseURL)/states/all")
         components?.queryItems = boundingBox.queryItems
-        
+
         guard let url = components?.url else {
             throw OpenSkyError.invalidResponse
         }
-        
+
+        return url
+    }
+
+    /// Build URL for the flight history endpoint
+    private func buildHistoryURL(icao24: String, timeFrom: Int, timeTo: Int) throws -> URL {
+        var components = URLComponents(string: "\(config.baseURL)/api/states/all")
+        components?.queryItems = [
+            URLQueryItem(name: "icao24", value: icao24),
+            URLQueryItem(name: "time", value: String(timeFrom)),
+            URLQueryItem(name: "endTime", value: String(timeTo))
+        ]
+
+        guard let url = components?.url else {
+            throw OpenSkyError.invalidResponse
+        }
+
         return url
     }
 }

--- a/UpThere/ViewModels/UpThereViewModel.swift
+++ b/UpThere/ViewModels/UpThereViewModel.swift
@@ -14,6 +14,15 @@ class UpThereViewModel {
     var errorMessage: String?
     var lastUpdateTime: Date?
     
+    /// Flight trails keyed by ICAO24
+    var trails: [String: FlightTrail] = [:]
+    
+    /// Complete historical trail for the selected flight (fetched from API)
+    var selectedFlightTrail: FlightTrail?
+    
+    /// Whether we're currently fetching historical data for the selected flight
+    var isLoadingTrail = false
+    
     // MARK: - Services
     private let flightService: FlightService
     private let locationService: LocationService
@@ -66,6 +75,8 @@ class UpThereViewModel {
         AppLogger.viewModel.info("Stopping flight tracking")
         stopAutoRefresh()
         locationService.stopUpdating()
+        trails.removeAll()
+        selectedFlightTrail = nil
     }
     
     /// Manual refresh
@@ -88,9 +99,15 @@ class UpThereViewModel {
             )
             AppLogger.viewModel.debug("Fetching flights in bounding box")
             
-            self.flights = try await flightService.fetchFlights(in: boundingBox)
-            lastUpdateTime = Date()
-            AppLogger.viewModel.debug("Refresh complete: \(self.flights.count, privacy: .public) flights")
+            let newFlights = try await flightService.fetchFlights(in: boundingBox)
+            let fetchTime = Date()
+            
+            // Update trails: add new positions for flights we just received
+            updateTrails(with: newFlights, at: fetchTime)
+            
+            self.flights = newFlights
+            lastUpdateTime = fetchTime
+            AppLogger.viewModel.debug("Refresh complete: \(self.flights.count, privacy: .public) flights, \(self.trails.count, privacy: .public) trails")
         } catch {
             errorMessage = error.localizedDescription
             AppLogger.viewModel.error("Refresh failed: \(error.localizedDescription, privacy: .public)")
@@ -99,9 +116,101 @@ class UpThereViewModel {
         isLoading = false
     }
     
-    /// Select a flight to show details
+    /// Update trails with new flight positions
+    private func updateTrails(with flights: [Flight], at date: Date) {
+        // Track which ICAO24s are still active
+        let activeIcao24s = Set(flights.map(\.id))
+        
+        for flight in flights {
+            guard let coordinate = flight.coordinate else { continue }
+            
+            if var trail = trails[flight.id] {
+                // Append new position to existing trail
+                trail.append(date: date, coordinate: coordinate)
+                trails[flight.id] = trail
+            } else {
+                // Create new trail
+                var trail = FlightTrail(icao24: flight.id)
+                trail.append(date: date, coordinate: coordinate)
+                trails[flight.id] = trail
+            }
+        }
+        
+        // Remove trails for flights that are no longer active AND older than max trail age
+        let cutoff = date.addingTimeInterval(-FlightTrail.maxTrailAge)
+        trails = trails.filter { icao24, trail in
+            if activeIcao24s.contains(icao24) { return true }
+            return trail.positions.contains { $0.date >= cutoff }
+        }
+    }
+    
+    /// Fetch complete historical trail for the selected flight
+    func fetchSelectedFlightTrail() async {
+        guard let flight = selectedFlight else {
+            selectedFlightTrail = nil
+            return
+        }
+        
+        isLoadingTrail = true
+        AppLogger.viewModel.debug("Fetching complete trail for \(flight.id, privacy: .public)")
+        
+        do {
+            // Fetch last 24 hours of history (OpenSky free tier limit)
+            let timeTo = Int(Date().timeIntervalSince1970)
+            let timeFrom = timeTo - (24 * 3600) // 24 hours ago
+            
+            let positions = try await flightService.fetchFlightHistory(
+                icao24: flight.id,
+                timeFrom: timeFrom,
+                timeTo: timeTo
+            )
+            
+            let trailPositions = positions.compactMap { pos -> (date: Date, coordinate: CLLocationCoordinate2D)? in
+                guard pos.latitude >= -90 && pos.latitude <= 90,
+                      pos.longitude >= -180 && pos.longitude <= 180 else {
+                    return nil
+                }
+                return (
+                    date: pos.date,
+                    coordinate: CLLocationCoordinate2D(latitude: pos.latitude, longitude: pos.longitude)
+                )
+            }
+            
+            var trail = FlightTrail(icao24: flight.id)
+            trail.setCompleteHistory(positions: trailPositions)
+            selectedFlightTrail = trail
+            
+            AppLogger.viewModel.debug("Fetched \(trailPositions.count, privacy: .public) positions for selected flight trail")
+        } catch {
+            AppLogger.viewModel.error("Failed to fetch flight trail: \(error.localizedDescription, privacy: .public)")
+            // Fall back to accumulated trail
+            if let accumulatedTrail = trails[flight.id] {
+                selectedFlightTrail = accumulatedTrail
+            }
+        }
+        
+        isLoadingTrail = false
+    }
+    
+    /// Select a flight to show details (toggle: tap same flight to deselect)
     func selectFlight(_ flight: Flight?) {
-        selectedFlight = flight
+        if let flight = flight, flight.id == selectedFlight?.id {
+            // Tapping the same flight → deselect
+            selectedFlight = nil
+            selectedFlightTrail = nil
+            AppLogger.viewModel.debug("Deselected flight \(flight.id, privacy: .public)")
+        } else if let flight = flight {
+            // Selecting a new flight
+            selectedFlight = flight
+            Task {
+                await fetchSelectedFlightTrail()
+            }
+            AppLogger.viewModel.debug("Selected flight \(flight.id, privacy: .public)")
+        } else {
+            // Deselecting (e.g., tapping empty space)
+            selectedFlight = nil
+            selectedFlightTrail = nil
+        }
     }
     
     /// Request location permission

--- a/UpThere/Views/ContentView.swift
+++ b/UpThere/Views/ContentView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// Adaptive content view - split view on iPad, tab view on iPhone
 struct ContentView: View {
     @State private var viewModel = UpThereViewModel()
-    @State private var selectedFlightForDetail: Flight?
+    @State private var showDetail = false
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     
     var body: some View {
@@ -11,28 +11,36 @@ struct ContentView: View {
             if horizontalSizeClass == .regular {
                 // iPad: Split view with list and map
                 NavigationSplitView {
-                    FlightListView(viewModel: viewModel, onFlightSelected: { flight in
-                        selectedFlightForDetail = flight
-                    })
+                    FlightListView(
+                        viewModel: viewModel,
+                        onFlightTapped: { viewModel.selectFlight($0) },
+                        showDetail: $showDetail
+                    )
                     .navigationSplitViewColumnWidth(min: 300, ideal: 350, max: 400)
                 } detail: {
-                    FlightMapView(viewModel: viewModel, onFlightSelected: { flight in
-                        selectedFlightForDetail = flight
-                    })
+                    FlightMapView(
+                        viewModel: viewModel,
+                        onFlightTapped: { viewModel.selectFlight($0) },
+                        showDetail: $showDetail
+                    )
                 }
             } else {
                 // iPhone: Tab-based navigation
                 TabView {
-                    FlightMapView(viewModel: viewModel, onFlightSelected: { flight in
-                        selectedFlightForDetail = flight
-                    })
+                    FlightMapView(
+                        viewModel: viewModel,
+                        onFlightTapped: { viewModel.selectFlight($0) },
+                        showDetail: $showDetail
+                    )
                     .tabItem {
                         Label("Map", systemImage: "map")
                     }
                     
-                    FlightListView(viewModel: viewModel, onFlightSelected: { flight in
-                        selectedFlightForDetail = flight
-                    })
+                    FlightListView(
+                        viewModel: viewModel,
+                        onFlightTapped: { viewModel.selectFlight($0) },
+                        showDetail: $showDetail
+                    )
                     .tabItem {
                         Label("Flights", systemImage: "airplane")
                     }
@@ -45,8 +53,10 @@ struct ContentView: View {
         .onDisappear {
             viewModel.stopTracking()
         }
-        .sheet(item: $selectedFlightForDetail) { flight in
-            FlightDetailView(flight: flight)
+        .sheet(isPresented: $showDetail) {
+            if let flight = viewModel.selectedFlight {
+                FlightDetailView(flight: flight, viewModel: viewModel)
+            }
         }
     }
 }

--- a/UpThere/Views/FlightDetailView.swift
+++ b/UpThere/Views/FlightDetailView.swift
@@ -4,7 +4,10 @@ import MapKit
 /// Detail view shown when a flight is selected
 struct FlightDetailView: View {
     let flight: Flight
+    @Bindable var viewModel: UpThereViewModel
     @Environment(\.dismiss) private var dismiss
+    
+    @State private var cameraPosition: MapCameraPosition = .automatic
     
     var body: some View {
         NavigationStack {
@@ -27,6 +30,18 @@ struct FlightDetailView: View {
                     }
                     .padding()
                     .background(Color.orange.opacity(0.1))
+                    
+                    // Trail map
+                    if let trail = viewModel.selectedFlightTrail, trail.isValid {
+                        trailMapView(trail: trail)
+                    } else if viewModel.isLoadingTrail {
+                        HStack {
+                            Spacer()
+                            ProgressView("Loading flight trail...")
+                            Spacer()
+                        }
+                        .padding()
+                    }
                     
                     // Info
                     Group {
@@ -111,5 +126,50 @@ struct FlightDetailView: View {
                 }
             }
         }
+    }
+    
+    @ViewBuilder
+    private func trailMapView(trail: FlightTrail) -> some View {
+        Group {
+            Map(position: $cameraPosition) {
+                // Trail polyline
+                MapPolyline(coordinates: trail.coordinates)
+                    .stroke(Color.orange, lineWidth: 3)
+                
+                // Current position marker
+                if let currentCoord = flight.coordinate {
+                    Annotation(flight.formattedCallsign, coordinate: currentCoord) {
+                        Image(systemName: "airplane")
+                            .font(.title2)
+                            .foregroundColor(.orange)
+                            .rotationEffect(.degrees(flight.trueTrack ?? 0))
+                            .padding(8)
+                            .background(Color.orange.opacity(0.3), in: Circle())
+                            .overlay {
+                                Circle()
+                                    .stroke(Color.orange, lineWidth: 3)
+                            }
+                    }
+                }
+                
+                // Trail start marker
+                if let startCoord = trail.positions.first?.coordinate {
+                    Annotation("Start", coordinate: startCoord) {
+                        Circle()
+                            .fill(.green)
+                            .frame(width: 10, height: 10)
+                    }
+                }
+            }
+            .frame(height: 200)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .onAppear {
+                // Set camera to show the full trail
+                if let coordinateRegion = trail.coordinateRegion {
+                    cameraPosition = .region(coordinateRegion)
+                }
+            }
+        }
+        .padding(.horizontal)
     }
 }

--- a/UpThere/Views/FlightListView.swift
+++ b/UpThere/Views/FlightListView.swift
@@ -4,7 +4,8 @@ import CoreLocation
 /// List view showing all flights
 struct FlightListView: View {
     @Bindable var viewModel: UpThereViewModel
-    var onFlightSelected: FlightSelectionHandler?
+    var onFlightTapped: FlightSelectionHandler?
+    @Binding var showDetail: Bool
     @State private var sortOrder = SortOrder.distance
     
     enum SortOrder: String, CaseIterable {
@@ -30,11 +31,18 @@ struct FlightListView: View {
     
     var body: some View {
         List(sortedFlights) { flight in
-            FlightRowView(flight: flight, userLocation: viewModel.userLocation)
-                .contentShape(Rectangle())
-                .onTapGesture {
-                    onFlightSelected?(flight)
-                }
+            FlightRowView(
+                flight: flight,
+                userLocation: viewModel.userLocation,
+                isSelected: viewModel.selectedFlight?.id == flight.id,
+                onTapped: { onFlightTapped?(flight) },
+                showDetail: $showDetail
+            )
+            .listRowBackground(
+                viewModel.selectedFlight?.id == flight.id
+                    ? Color.orange.opacity(0.1)
+                    : Color.clear
+            )
         }
         .listStyle(.plain)
         .refreshable {
@@ -91,9 +99,28 @@ struct FlightListView: View {
 struct FlightRowView: View {
     let flight: Flight
     let userLocation: CLLocation?
+    let isSelected: Bool
+    let onTapped: () -> Void
+    @Binding var showDetail: Bool
     
     var body: some View {
         HStack(spacing: 12) {
+            // Selection indicators (left side)
+            if isSelected {
+                Button {
+                    showDetail = true
+                } label: {
+                    Image(systemName: "info.circle")
+                        .foregroundColor(.orange)
+                        .font(.title3)
+                }
+                .buttonStyle(.plain)
+                
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundColor(.orange)
+                    .font(.title3)
+            }
+            
             // Flight icon with rotation
             Image(systemName: "airplane")
                 .font(.title2)
@@ -136,5 +163,9 @@ struct FlightRowView: View {
             }
         }
         .padding(.vertical, 4)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            onTapped()
+        }
     }
 }

--- a/UpThere/Views/FlightMapView.swift
+++ b/UpThere/Views/FlightMapView.swift
@@ -7,7 +7,8 @@ typealias FlightSelectionHandler = (Flight) -> Void
 /// Map view showing flights as annotations
 struct FlightMapView: View {
     @Bindable var viewModel: UpThereViewModel
-    var onFlightSelected: FlightSelectionHandler?
+    var onFlightTapped: FlightSelectionHandler?
+    @Binding var showDetail: Bool
     
     @State private var cameraPosition: MapCameraPosition = .automatic
     @State private var hasInitialLocationSet = false
@@ -28,17 +29,36 @@ struct FlightMapView: View {
                     }
                 }
                 
+                // Flight trails (polylines) - accumulated 5-minute trails
+                ForEach(Array(viewModel.trails.values)) { trail in
+                    if trail.isValid {
+                        let isSelected = viewModel.selectedFlight?.id == trail.id
+                        MapPolyline(coordinates: trail.coordinates)
+                            .stroke(isSelected ? Color.orange : Color.orange.opacity(0.35), lineWidth: isSelected ? 2.5 : 1.5)
+                    }
+                }
+                
+                // Selected flight complete trail (from API)
+                if let selectedTrail = viewModel.selectedFlightTrail, selectedTrail.isValid {
+                    MapPolyline(coordinates: selectedTrail.coordinates)
+                        .stroke(Color.orange, lineWidth: 3)
+                }
+                
                 // Flight markers
                 ForEach(viewModel.flights) { flight in
                     if let coordinate = flight.coordinate {
                         Annotation(flight.formattedCallsign, coordinate: coordinate) {
                             FlightAnnotationView(flight: flight, isSelected: viewModel.selectedFlight?.id == flight.id)
                                 .onTapGesture {
-                                    onFlightSelected?(flight)
+                                    onFlightTapped?(flight)
                                 }
                         }
                     }
                 }
+            }
+            .onTapGesture {
+                // Tap on empty map area → deselect
+                viewModel.selectFlight(nil)
             }
             .mapControls {
                 MapUserLocationButton()
@@ -56,8 +76,13 @@ struct FlightMapView: View {
             VStack {
                 HStack {
                     Spacer()
-                    refreshButton
-                        .offset(x: 20, y: 40)
+                    VStack(spacing: 12) {
+                        // Details button - shown when a flight is selected
+                        if viewModel.selectedFlight != nil {
+                            detailsButton
+                        }
+                        refreshButton
+                    }
                 }
                 Spacer()
                 if let error = viewModel.errorMessage {
@@ -80,6 +105,17 @@ struct FlightMapView: View {
                 ))
                 hasInitialLocationSet = true
             }
+        }
+    }
+    
+    private var detailsButton: some View {
+        Button {
+            showDetail = true
+        } label: {
+            Image(systemName: "info.circle")
+                .font(.title2)
+                .padding(10)
+                .background(.regularMaterial, in: Circle())
         }
     }
     

--- a/UpThereTests/FlightServiceTests.swift
+++ b/UpThereTests/FlightServiceTests.swift
@@ -202,4 +202,81 @@ struct FlightServiceTests {
             #expect(isNetworkError, "Expected network error")
         }
     }
+    
+    // MARK: - Historical Flight Data Tests
+    
+    @Test
+    func testFetchFlightHistorySuccess() async throws {
+        let session = createMockSession { request in
+            if request.url?.path.contains("auth") == true {
+                let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+                let tokenResponse = """
+                {"access_token": "mock_token", "expires_in": 1800}
+                """.data(using: .utf8)!
+                return (response, tokenResponse)
+            } else {
+                let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+                return (response, TestData.validHistoryResponse)
+            }
+        }
+        
+        let config = OpenSkyConfig(clientId: "test", clientSecret: "test")
+        let service = FlightService(config: config, session: session)
+        
+        let positions = try await service.fetchFlightHistory(icao24: "3c6444", timeFrom: 1704063600, timeTo: 1704067200)
+        
+        #expect(positions.count == 3)
+        #expect(positions[0].latitude == 37.7000)
+        #expect(positions[0].longitude == -122.5000)
+        #expect(positions[2].latitude == 37.7749)
+    }
+    
+    @Test
+    func testFetchFlightHistoryEmpty() async throws {
+        let session = createMockSession { request in
+            if request.url?.path.contains("auth") == true {
+                let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+                let tokenResponse = """
+                {"access_token": "mock_token", "expires_in": 1800}
+                """.data(using: .utf8)!
+                return (response, tokenResponse)
+            } else {
+                let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+                return (response, TestData.emptyHistoryResponse)
+            }
+        }
+        
+        let config = OpenSkyConfig(clientId: "test", clientSecret: "test")
+        let service = FlightService(config: config, session: session)
+        
+        let positions = try await service.fetchFlightHistory(icao24: "3c6444", timeFrom: 1704063600, timeTo: 1704067200)
+        
+        #expect(positions.isEmpty)
+    }
+    
+    @Test
+    func testFetchFlightHistoryRateLimit() async throws {
+        let session = createMockSession { request in
+            if request.url?.path.contains("auth") == true {
+                let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+                let tokenResponse = """
+                {"access_token": "mock_token", "expires_in": 1800}
+                """.data(using: .utf8)!
+                return (response, tokenResponse)
+            } else {
+                let response = HTTPURLResponse(url: request.url!, statusCode: 429, httpVersion: nil, headerFields: nil)!
+                return (response, "Too Many Requests".data(using: .utf8)!)
+            }
+        }
+        
+        let config = OpenSkyConfig(clientId: "test", clientSecret: "test")
+        let service = FlightService(config: config, session: session)
+        
+        do {
+            _ = try await service.fetchFlightHistory(icao24: "3c6444", timeFrom: 1704063600, timeTo: 1704067200)
+            #expect(Bool(false), "Should have thrown rate limit error")
+        } catch {
+            #expect(error is OpenSkyError)
+        }
+    }
 }

--- a/UpThereTests/FlightTrailTests.swift
+++ b/UpThereTests/FlightTrailTests.swift
@@ -1,0 +1,209 @@
+import Foundation
+import Testing
+import CoreLocation
+
+@testable import UpThere
+
+struct FlightTrailTests {
+    
+    // MARK: - Initialization Tests
+    
+    @Test
+    func testInitCreatesEmptyTrail() {
+        let trail = FlightTrail(icao24: "3c6444")
+        
+        #expect(trail.id == "3c6444")
+        #expect(trail.positionCount == 0)
+        #expect(!trail.isValid)
+        #expect(!trail.isCompleteHistory)
+    }
+    
+    // MARK: - Append Tests
+    
+    @Test
+    func testAppendAddsPosition() {
+        var trail = FlightTrail(icao24: "3c6444")
+        let date = Date()
+        let coord = CLLocationCoordinate2D(latitude: 37.7749, longitude: -122.4194)
+        
+        trail.append(date: date, coordinate: coord)
+        
+        #expect(trail.positionCount == 1)
+        #expect(trail.positions[0].date == date)
+        #expect(trail.positions[0].coordinate.latitude == 37.7749)
+        #expect(trail.positions[0].coordinate.longitude == -122.4194)
+    }
+    
+    @Test
+    func testAppendMultiplePositionsKeepsOrder() {
+        var trail = FlightTrail(icao24: "3c6444")
+        let baseDate = Date()
+        
+        trail.append(date: baseDate.addingTimeInterval(10), coordinate: CLLocationCoordinate2D(latitude: 37.78, longitude: -122.42))
+        trail.append(date: baseDate, coordinate: CLLocationCoordinate2D(latitude: 37.77, longitude: -122.41))
+        trail.append(date: baseDate.addingTimeInterval(5), coordinate: CLLocationCoordinate2D(latitude: 37.775, longitude: -122.415))
+        
+        // Should be sorted by date
+        #expect(trail.positions[0].date == baseDate)
+        #expect(trail.positions[1].date == baseDate.addingTimeInterval(5))
+        #expect(trail.positions[2].date == baseDate.addingTimeInterval(10))
+    }
+    
+    @Test
+    func testAppendSkipsDuplicateTimestamp() {
+        var trail = FlightTrail(icao24: "3c6444")
+        let date = Date()
+        
+        trail.append(date: date, coordinate: CLLocationCoordinate2D(latitude: 37.77, longitude: -122.41))
+        trail.append(date: date, coordinate: CLLocationCoordinate2D(latitude: 38.00, longitude: -123.00))
+        
+        #expect(trail.positionCount == 1)
+        #expect(trail.positions[0].coordinate.latitude == 37.77)
+    }
+    
+    // MARK: - Trim Tests
+    
+    @Test
+    func testTrimRemovesOldPositions() {
+        var trail = FlightTrail(icao24: "3c6444")
+        let now = Date()
+        
+        // Add position 6 minutes ago (should be trimmed)
+        trail.append(date: now.addingTimeInterval(-360), coordinate: CLLocationCoordinate2D(latitude: 37.77, longitude: -122.41))
+        // Add position 4 minutes ago (should be kept)
+        trail.append(date: now.addingTimeInterval(-240), coordinate: CLLocationCoordinate2D(latitude: 37.78, longitude: -122.42))
+        // Add position now (should be kept)
+        trail.append(date: now, coordinate: CLLocationCoordinate2D(latitude: 37.79, longitude: -122.43))
+        
+        #expect(trail.positionCount == 2)
+        #expect(trail.positions[0].date == now.addingTimeInterval(-240))
+        #expect(trail.positions[1].date == now)
+    }
+    
+    @Test
+    func testTrimRemovesAllOldPositions() {
+        var trail = FlightTrail(icao24: "3c6444")
+        let now = Date()
+        
+        trail.append(date: now.addingTimeInterval(-360), coordinate: CLLocationCoordinate2D(latitude: 37.77, longitude: -122.41))
+        trail.append(date: now.addingTimeInterval(-350), coordinate: CLLocationCoordinate2D(latitude: 37.78, longitude: -122.42))
+        
+        // Add a new position now — the old ones are > 5 min before this
+        trail.append(date: now, coordinate: CLLocationCoordinate2D(latitude: 37.79, longitude: -122.43))
+        
+        #expect(trail.positionCount == 1)
+        #expect(trail.positions[0].date == now)
+    }
+    
+    // MARK: - Complete History Tests
+    
+    @Test
+    func testSetCompleteHistory() {
+        var trail = FlightTrail(icao24: "3c6444")
+        let now = Date()
+        
+        let positions = [
+            (date: now.addingTimeInterval(-3600), coordinate: CLLocationCoordinate2D(latitude: 37.77, longitude: -122.41)),
+            (date: now.addingTimeInterval(-1800), coordinate: CLLocationCoordinate2D(latitude: 37.78, longitude: -122.42)),
+            (date: now, coordinate: CLLocationCoordinate2D(latitude: 37.79, longitude: -122.43))
+        ]
+        
+        trail.setCompleteHistory(positions: positions)
+        
+        #expect(trail.isCompleteHistory)
+        #expect(trail.positionCount == 3)
+        // Should NOT trim old positions since it's a complete history
+        #expect(trail.positions[0].date == now.addingTimeInterval(-3600))
+    }
+    
+    @Test
+    func testCompleteHistoryDoesNotTrimOnAppend() {
+        var trail = FlightTrail(icao24: "3c6444")
+        let now = Date()
+        
+        trail.setCompleteHistory(positions: [
+            (date: now.addingTimeInterval(-3600), coordinate: CLLocationCoordinate2D(latitude: 37.77, longitude: -122.41))
+        ])
+        
+        // Append a new position — should NOT trigger trimming
+        trail.append(date: now, coordinate: CLLocationCoordinate2D(latitude: 37.79, longitude: -122.43))
+        
+        #expect(trail.positionCount == 2)
+        #expect(trail.positions[0].date == now.addingTimeInterval(-3600))
+    }
+    
+    @Test
+    func testResetToAccumulated() {
+        var trail = FlightTrail(icao24: "3c6444")
+        let now = Date()
+        
+        trail.setCompleteHistory(positions: [
+            (date: now.addingTimeInterval(-3600), coordinate: CLLocationCoordinate2D(latitude: 37.77, longitude: -122.41)),
+            (date: now, coordinate: CLLocationCoordinate2D(latitude: 37.79, longitude: -122.43))
+        ])
+        
+        trail.resetToAccumulated()
+        
+        #expect(!trail.isCompleteHistory)
+        // Should trim the old position
+        #expect(trail.positionCount == 1)
+        #expect(trail.positions[0].date == now)
+    }
+    
+    // MARK: - Coordinates Helper Tests
+    
+    @Test
+    func testCoordinatesReturnsArrayOfCLLocationCoordinate2D() {
+        var trail = FlightTrail(icao24: "3c6444")
+        let now = Date()
+        
+        trail.append(date: now, coordinate: CLLocationCoordinate2D(latitude: 37.77, longitude: -122.41))
+        trail.append(date: now.addingTimeInterval(5), coordinate: CLLocationCoordinate2D(latitude: 37.78, longitude: -122.42))
+        
+        let coords = trail.coordinates
+        
+        #expect(coords.count == 2)
+        #expect(coords[0].latitude == 37.77)
+        #expect(coords[1].latitude == 37.78)
+    }
+    
+    // MARK: - isValid Tests
+    
+    @Test
+    func testIsValidRequiresAtLeastTwoPositions() {
+        var trail = FlightTrail(icao24: "3c6444")
+        
+        #expect(!trail.isValid)
+        
+        let now = Date()
+        trail.append(date: now, coordinate: CLLocationCoordinate2D(latitude: 37.77, longitude: -122.41))
+        #expect(!trail.isValid)
+        
+        trail.append(date: now.addingTimeInterval(5), coordinate: CLLocationCoordinate2D(latitude: 37.78, longitude: -122.42))
+        #expect(trail.isValid)
+    }
+    
+    // MARK: - coordinateRegion Tests
+    
+    @Test
+    func testCoordinateRegionReturnsNilForEmptyTrail() {
+        let trail = FlightTrail(icao24: "3c6444")
+        #expect(trail.coordinateRegion == nil)
+    }
+    
+    @Test
+    func testCoordinateRegionEncompassesPositions() {
+        var trail = FlightTrail(icao24: "3c6444")
+        let now = Date()
+        
+        trail.append(date: now, coordinate: CLLocationCoordinate2D(latitude: 37.77, longitude: -122.41))
+        trail.append(date: now.addingTimeInterval(5), coordinate: CLLocationCoordinate2D(latitude: 37.79, longitude: -122.39))
+        
+        let region = trail.coordinateRegion
+        
+        #expect(region != nil)
+        // Center should be roughly midpoint
+        #expect(abs(region!.center.latitude - 37.78) < 0.01)
+        #expect(abs(region!.center.longitude - (-122.40)) < 0.01)
+    }
+}

--- a/UpThereTests/OpenSkyResponseTests.swift
+++ b/UpThereTests/OpenSkyResponseTests.swift
@@ -133,4 +133,60 @@ struct OpenSkyResponseTests {
         #expect(flights[0].longitude == nil)
         #expect(flights[0].baroAltitude == nil)
     }
+    
+    // MARK: - OpenSkyHistoryResponse Tests
+    
+    @Test
+    func testHistoryParseValidResponse() throws {
+        let response = try OpenSkyHistoryResponse.parse(from: TestData.validHistoryResponse)
+        
+        #expect(response.time == 1704067200)
+        #expect(response.states?.count == 3)
+    }
+    
+    @Test
+    func testHistoryParseEmptyResponse() throws {
+        let response = try OpenSkyHistoryResponse.parse(from: TestData.emptyHistoryResponse)
+        
+        #expect(response.time == 1704067200)
+        #expect(response.states?.isEmpty == true)
+    }
+    
+    @Test
+    func testHistoryToPositions() throws {
+        let response = try OpenSkyHistoryResponse.parse(from: TestData.validHistoryResponse)
+        let positions = response.toPositions()
+        
+        #expect(positions.count == 3)
+        // First position
+        #expect(positions[0].latitude == 37.7000)
+        #expect(positions[0].longitude == -122.5000)
+        #expect(positions[0].date == Date(timeIntervalSince1970: 1704063600))
+        // Last position
+        #expect(positions[2].latitude == 37.7749)
+        #expect(positions[2].longitude == -122.4194)
+    }
+    
+    @Test
+    func testHistoryToPositionsEmptyStates() throws {
+        let response = try OpenSkyHistoryResponse.parse(from: TestData.emptyHistoryResponse)
+        let positions = response.toPositions()
+        
+        #expect(positions.isEmpty)
+    }
+    
+    @Test
+    func testHistoryToPositionsNullStates() throws {
+        let data = """
+        {
+            "time": 1704067200,
+            "states": null
+        }
+        """.data(using: .utf8)!
+        
+        let response = try OpenSkyHistoryResponse.parse(from: data)
+        let positions = response.toPositions()
+        
+        #expect(positions.isEmpty)
+    }
 }

--- a/UpThereTests/TestHelpers/TestData.swift
+++ b/UpThereTests/TestHelpers/TestData.swift
@@ -86,4 +86,26 @@ enum TestData {
         "states": []
     }
     """.data(using: .utf8)!
+    
+    // MARK: - Historical Flight Data
+    
+    /// Valid historical flight history response
+    static let validHistoryResponse = """
+    {
+        "time": 1704067200,
+        "states": [
+            ["3c6444", "UAL1234 ", "United States", 1704063600, 1704063600, -122.5000, 37.7000, 10000.0, false, 250.0, 180.0, 5.0, null, null, "1234", false, 0, 4],
+            ["3c6444", "UAL1234 ", "United States", 1704065400, 1704065400, -122.4500, 37.7400, 10500.0, false, 255.0, 182.0, 3.0, null, null, "1234", false, 0, 4],
+            ["3c6444", "UAL1234 ", "United States", 1704067200, 1704067200, -122.4194, 37.7749, 10000.0, false, 250.5, 180.0, 5.0, null, null, "1234", false, 0, 4]
+        ]
+    }
+    """.data(using: .utf8)!
+    
+    /// Historical response with no states
+    static let emptyHistoryResponse = """
+    {
+        "time": 1704067200,
+        "states": []
+    }
+    """.data(using: .utf8)!
 }


### PR DESCRIPTION
## Summary

- **Flight Trails**: Show recent flight paths on the map for each aircraft. Trails are built client-side by accumulating positions from each 5-second refresh (5-minute rolling window). Selecting a flight fetches its complete historical trail from the OpenSky API.
- **Flight Selection**: Unified selection mechanism across map and list views. Tap to select/deselect (toggle), tap empty map space to deselect, tap another flight to switch selection. Visual highlighting stays in sync across all views.

## Changes

### Models
- **`FlightTrail.swift`** (new) — Stores ordered timestamped positions per ICAO24, with 5-min auto-trimming, complete history support, and `coordinateRegion` helper
- **`OpenSkyResponse.swift`** — Added `OpenSkyHistoryResponse` for parsing historical API responses

### Services
- **`FlightService.swift`** — Added `fetchFlightHistory(icao24:timeFrom:timeTo:)` with auth, token refresh, rate limiting, and error handling

### ViewModel
- **`UpThereViewModel.swift`** — Added `trails`, `selectedFlightTrail`, `isLoadingTrail`; toggle-based `selectFlight(_:)`; trail accumulation on each refresh; `fetchSelectedFlightTrail()` for selected flights

### Views
- **`ContentView.swift`** — Replaced `selectedFlightForDetail` with `showDetail` binding; wires `viewModel.selectFlight` as the single selection source
- **`FlightMapView.swift`** — Renders `MapPolyline` for each trail; tap annotation to select; tap empty space to deselect; floating info button when flight is selected
- **`FlightListView.swift`** — Row tap to select/deselect; checkmark + info button for selected rows; highlighted row background
- **`FlightDetailView.swift`** — Added trail map with polyline, current position marker, and start marker

### Tests
- **`FlightTrailTests.swift`** (new) — 14 tests covering init, append, trim, complete history, reset, coordinates, isValid, coordinateRegion
- **`OpenSkyResponseTests.swift`** — 5 new tests for `OpenSkyHistoryResponse` parsing
- **`FlightServiceTests.swift`** — 3 new tests for `fetchFlightHistory`
- **`TestData.swift`** — Added historical response fixtures

### Requirements
- **`SYSREQ-007`** — Flight Trails (6 scenarios)
- **`UIREQ-005`** — Flight Selection (7 scenarios)

## Test Results

All 82 tests pass across 6 suites. Both iOS and macOS targets build successfully.

Closes #3