### PR TITLE
✨ Enhance flight details with airline info, route data, and ETA

### DIFF
--- a/Requirements/ui/UIREQ-003-flight-detail-view.md
+++ b/Requirements/ui/UIREQ-003-flight-detail-view.md
@@ -4,7 +4,7 @@ title: Flight Detail View
 priority: medium
 type: feature
 status: implemented
-tags: [ui, detail, sheet, information]
+tags: [ui, detail, sheet, information, route, airline]
 scenarios:
   - id: SC-012-01
     name: Display flight details
@@ -26,26 +26,51 @@ scenarios:
     given: A flight with a valid trueTrack is selected
     when: The detail sheet is displayed
     then: The header shows a large airplane icon rotated by the flight's heading
+  - id: SC-012-05
+    name: Display airline logo and route info
+    given: A flight is selected and route data is available from AviationStack API
+    when: The detail sheet is displayed
+    then: The header shows the airline logo (or ICAO designator badge as fallback), route (e.g., "LAX → BOS"), and flight status badge
+  - id: SC-012-06
+    name: Display route section with origin, destination, and ETA
+    given: A flight is selected and route data is available
+    when: The detail sheet is displayed
+    then: A "Route" section shows airline name, origin airport, destination airport, and estimated arrival time
+  - id: SC-012-07
+    name: Show loading state for route info
+    given: A flight is selected and route data is being fetched
+    when: The detail sheet is displayed
+    then: A "Loading route info..." progress indicator is shown in the Route section
+  - id: SC-012-08
+    name: Hide route section when no data available
+    given: A flight is selected but no route data is available (API not configured or no match)
+    when: The detail sheet is displayed
+    then: The Route section is not shown
 ---
 
 # UIREQ-003: Flight Detail View
 
 ## Description
 
-The flight detail view is presented as a modal sheet when a flight is selected from either the list or map. It displays comprehensive information about the selected flight organized into sections.
+The flight detail view is presented as a modal sheet when a flight is selected from either the list or map. It displays comprehensive information about the selected flight organized into sections, including airline branding and route information when available.
 
 ## Source Files
 
 - `UpThere/Views/FlightDetailView.swift` — Detail sheet view
+- `UpThere/Models/FlightRouteInfo.swift` — Route data model
+- `UpThere/Services/FlightRouteService.swift` — AviationStack API service
+- `UpThere/ViewModels/UpThereViewModel.swift` — Route fetching orchestration
 
 ## Acceptance Criteria
 
 1. The detail view is presented as a `.sheet` from `ContentView`
 2. The view is wrapped in a `NavigationStack` with a "Done" button in the toolbar
 3. Content is scrollable via `ScrollView`
-4. Information is organized into three sections: Flight Information, Position, Coordinates
+4. Information is organized into sections: Route (if available), Flight Information, Position, Coordinates
 5. Sections are separated by `Divider` views
 6. Optional fields (altitude, speed, heading, coordinates) are conditionally displayed
+7. Airline logo is fetched from `https://images.kiwi.com/airlines/64/{IATA}.png` with fallback to ICAO designator badge
+8. Route section is only shown when route data is available or while loading
 
 ## Layout Structure
 
@@ -53,9 +78,21 @@ The flight detail view is presented as a modal sheet when a flight is selected f
 ┌─────────────────────────────────┐
 │ Navigation: "Flight Details" [Done]
 ├─────────────────────────────────┤
-│         [Airplane Icon]          │  ← 60pt, orange, rotated by trueTrack
+│   [Logo] [Airplane Icon]         │  ← Logo or ICAO badge + 60pt rotated airplane
 │           CALLSIGN               │  ← title2, bold
+│         LAX → BOS                │  ← route (if available)
+│        [En Route]                │  ← status badge (if available)
 │    (orange tinted background)    │
+├─────────────────────────────────┤
+│ Trail Map (if available)         │  ← 200px height map with trail
+├─────────────────────────────────┤
+│ Route (conditional)              │  ← headline, only if data available
+│ Airline:         United (UAL)    │
+│ Origin:          LAX             │
+│                  Los Angeles Intl│
+│ Destination:     BOS             │
+│                  Logan Intl      │
+│ Est. Arrival:    4:25 PM         │
 ├─────────────────────────────────┤
 │ Flight Information               │  ← headline
 │ Callsign:        CALLSIGN        │
@@ -77,8 +114,14 @@ The flight detail view is presented as a modal sheet when a flight is selected f
 
 | Section | Field | Format | Condition |
 |---------|-------|--------|-----------|
+| Header | Airline logo | `AsyncImage` from kiwi.com or ICAO badge | If route data with IATA code |
 | Header | Callsign | `formattedCallsign` (trimmed, uppercased) | Always |
-| Header | Airplane icon | 60pt, orange, rotated by `trueTrack` | Always |
+| Header | Route | `formattedRoute` (e.g., "LAX → BOS") | If route data available |
+| Header | Status badge | `displayStatus` with color | If route data with status |
+| Route | Airline | `formattedAirline` (e.g., "United Airlines (UAL)") | If route data with airline |
+| Route | Origin | `departureAirportIata` + `departureAirportName` | If route data with departure |
+| Route | Destination | `arrivalAirportIata` + `arrivalAirportName` | If route data with arrival |
+| Route | Est. Arrival | `estimatedArrival` or `scheduledArrival` as time | If route data with arrival time |
 | Flight Information | Callsign | `formattedCallsign` | Always |
 | Flight Information | Aircraft ID | `flight.id` (ICAO24) | Always |
 | Flight Information | Country | `flight.originCountry` | Always |
@@ -92,6 +135,11 @@ The flight detail view is presented as a modal sheet when a flight is selected f
 
 - Altitude, speed, and heading rows are entirely hidden when their values are nil
 - Coordinates rows are entirely hidden when their values are nil
-- The sheet is presented via `ContentView`'s `selectedFlightForDetail` state, not directly from the list or map
+- The Route section is hidden entirely when no route data is available and not loading
+- A loading indicator is shown in the Route section while route data is being fetched
+- If airline logo fails to load, an ICAO designator badge (e.g., "UAL" in monospaced text) is shown
+- If no airline designator can be extracted from callsign, a generic airplane icon is shown
+- The sheet is presented via `ContentView`'s `showDetail` binding, triggered by `viewModel.selectedFlight`
 - The `@Environment(\.dismiss)` is used for the Done button action
 - Bottom padding of 40pt ensures content is not obscured by safe area
+- Route info is fetched asynchronously when a flight is selected and cached in-memory

--- a/UpThere/Models/Flight.swift
+++ b/UpThere/Models/Flight.swift
@@ -67,6 +67,16 @@ struct Flight: Identifiable, Hashable {
     var formattedCallsign: String {
         callsign.trimmingCharacters(in: .whitespaces).uppercased()
     }
+    
+    /// ICAO airline designator extracted from callsign (first 3 characters, e.g., "UAL" from "UAL1234")
+    var airlineDesignator: String? {
+        let trimmed = formattedCallsign
+        guard trimmed.count >= 3 else { return nil }
+        let designator = String(trimmed.prefix(3))
+        // Validate it looks like an ICAO code (letters only)
+        guard designator.range(of: "^[A-Z]{3}$", options: .regularExpression) != nil else { return nil }
+        return designator
+    }
 }
 
 /// Extension for creating Flight from OpenSky state array

--- a/UpThere/Models/FlightRouteInfo.swift
+++ b/UpThere/Models/FlightRouteInfo.swift
@@ -1,0 +1,177 @@
+import Foundation
+
+/// Route information for a flight, fetched from AviationStack API
+struct FlightRouteInfo: Equatable {
+    /// Airline name (e.g., "United Airlines")
+    let airlineName: String?
+    
+    /// Airline IATA code (e.g., "UA")
+    let airlineIata: String?
+    
+    /// Airline ICAO code (e.g., "UAL")
+    let airlineIcao: String?
+    
+    /// Departure airport ICAO (e.g., "KLAX")
+    let departureAirportIcao: String?
+    
+    /// Departure airport IATA (e.g., "LAX")
+    let departureAirportIata: String?
+    
+    /// Departure airport full name
+    let departureAirportName: String?
+    
+    /// Arrival airport ICAO (e.g., "KBOS")
+    let arrivalAirportIcao: String?
+    
+    /// Arrival airport IATA (e.g., "BOS")
+    let arrivalAirportIata: String?
+    
+    /// Arrival airport full name
+    let arrivalAirportName: String?
+    
+    /// Scheduled departure time
+    let scheduledDeparture: Date?
+    
+    /// Estimated departure time
+    let estimatedDeparture: Date?
+    
+    /// Scheduled arrival time
+    let scheduledArrival: Date?
+    
+    /// Estimated arrival time
+    let estimatedArrival: Date?
+    
+    /// Flight status (e.g., "active", "landed", "scheduled")
+    let flightStatus: String?
+    
+    // MARK: - Computed Properties
+    
+    /// URL for the airline logo from kiwi.com
+    var logoURL: URL? {
+        guard let iata = airlineIata, !iata.isEmpty else { return nil }
+        return URL(string: "https://images.kiwi.com/airlines/64/\(iata).png")
+    }
+    
+    /// Formatted route string (e.g., "LAX → BOS")
+    var formattedRoute: String? {
+        guard let from = departureAirportIata, let to = arrivalAirportIata else { return nil }
+        return "\(from) → \(to)"
+    }
+    
+    /// Formatted airline display (e.g., "United Airlines (UAL)")
+    var formattedAirline: String? {
+        var parts: [String] = []
+        if let name = airlineName { parts.append(name) }
+        if let icao = airlineIcao { parts.append("(\(icao))") }
+        return parts.isEmpty ? nil : parts.joined(separator: " ")
+    }
+    
+    /// Whether we have any meaningful route data
+    var hasRouteData: Bool {
+        departureAirportIata != nil || arrivalAirportIata != nil || airlineName != nil
+    }
+}
+
+// MARK: - AviationStack API Response Parsing
+
+extension FlightRouteInfo {
+    /// Parse from AviationStack API response data
+    static func parse(from data: Data) throws -> FlightRouteInfo? {
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let flights = json["data"] as? [[String: Any]],
+              let flightData = flights.first else {
+            return nil
+        }
+        
+        // Parse airline info
+        let airline = flightData["airline"] as? [String: Any]
+        let airlineName = airline?["name"] as? String
+        let airlineIata = airline?["iata"] as? String
+        let airlineIcao = airline?["icao"] as? String
+        
+        // Parse departure info
+        let departure = flightData["departure"] as? [String: Any]
+        let depAirportIcao = departure?["icao"] as? String
+        let depAirportIata = departure?["iata"] as? String
+        let depAirportName = departure?["airport"] as? String
+        let scheduledDep = (departure?["scheduled"] as? String).flatMap { Self.isoDateFormatter.date(from: $0) }
+        let estimatedDep = (departure?["estimated"] as? String).flatMap { Self.isoDateFormatter.date(from: $0) }
+        
+        // Parse arrival info
+        let arrival = flightData["arrival"] as? [String: Any]
+        let arrAirportIcao = arrival?["icao"] as? String
+        let arrAirportIata = arrival?["iata"] as? String
+        let arrAirportName = arrival?["airport"] as? String
+        let scheduledArr = (arrival?["scheduled"] as? String).flatMap { Self.isoDateFormatter.date(from: $0) }
+        let estimatedArr = (arrival?["estimated"] as? String).flatMap { Self.isoDateFormatter.date(from: $0) }
+        
+        // Parse flight status
+        let flightStatus = flightData["flight_status"] as? String
+        
+        return FlightRouteInfo(
+            airlineName: airlineName,
+            airlineIata: airlineIata,
+            airlineIcao: airlineIcao,
+            departureAirportIcao: depAirportIcao,
+            departureAirportIata: depAirportIata,
+            departureAirportName: depAirportName,
+            arrivalAirportIcao: arrAirportIcao,
+            arrivalAirportIata: arrAirportIata,
+            arrivalAirportName: arrAirportName,
+            scheduledDeparture: scheduledDep,
+            estimatedDeparture: estimatedDep,
+            scheduledArrival: scheduledArr,
+            estimatedArrival: estimatedArr,
+            flightStatus: flightStatus
+        )
+    }
+    
+    /// ISO 8601 date formatter for AviationStack timestamps
+    private static let isoDateFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+}
+
+// MARK: - Display Helpers
+
+extension FlightRouteInfo {
+    /// Human-readable flight status
+    var displayStatus: String? {
+        guard let status = flightStatus else { return nil }
+        switch status.lowercased() {
+        case "active", "en-route", "en route":
+            return "En Route"
+        case "landed":
+            return "Landed"
+        case "scheduled":
+            return "Scheduled"
+        case "cancelled":
+            return "Cancelled"
+        case "diverted":
+            return "Diverted"
+        case "incidents", "incident":
+            return "Incident"
+        default:
+            return status.capitalized
+        }
+    }
+    
+    /// Status color for display
+    var statusColor: String {
+        guard let status = flightStatus?.lowercased() else { return "gray" }
+        switch status {
+        case "active", "en-route", "en route":
+            return "green"
+        case "landed":
+            return "blue"
+        case "cancelled":
+            return "red"
+        case "diverted":
+            return "orange"
+        default:
+            return "gray"
+        }
+    }
+}

--- a/UpThere/Services/AirlineDatabase.swift
+++ b/UpThere/Services/AirlineDatabase.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+/// Local airline database mapping ICAO codes to airline information
+/// Used as a fallback when the AviationStack API is not available
+enum AirlineDatabase {
+    
+    /// Look up airline info by ICAO code
+    static func lookup(icao: String) -> AirlineInfo? {
+        airlines[icao.uppercased()]
+    }
+    
+    /// Look up airline info by IATA code
+    static func lookupIata(_ iata: String) -> AirlineInfo? {
+        airlinesByIata[iata.uppercased()]
+    }
+}
+
+/// Airline information
+struct AirlineInfo {
+    let name: String
+    let iata: String
+    let icao: String
+}
+
+// MARK: - Airline Database
+
+private let airlines: [String: AirlineInfo] = {
+    var db = [String: AirlineInfo]()
+    
+    for info in airlineList {
+        db[info.icao.uppercased()] = info
+    }
+    return db
+}()
+
+private let airlinesByIata: [String: AirlineInfo] = {
+    var db = [String: AirlineInfo]()
+    
+    for info in airlineList {
+        db[info.iata.uppercased()] = info
+    }
+    return db
+}()
+
+// MARK: - Airline List
+
+private let airlineList: [AirlineInfo] = [
+    // North America
+    AirlineInfo(name: "United Airlines", iata: "UA", icao: "UAL"),
+    AirlineInfo(name: "American Airlines", iata: "AA", icao: "AAL"),
+    AirlineInfo(name: "Delta Air Lines", iata: "DL", icao: "DAL"),
+    AirlineInfo(name: "Southwest Airlines", iata: "WN", icao: "SWA"),
+    AirlineInfo(name: "JetBlue Airways", iata: "B6", icao: "JBU"),
+    AirlineInfo(name: "Alaska Airlines", iata: "AS", icao: "ASA"),
+    AirlineInfo(name: "Spirit Airlines", iata: "NK", icao: "NKS"),
+    AirlineInfo(name: "Frontier Airlines", iata: "F9", icao: "FFT"),
+    AirlineInfo(name: "Hawaiian Airlines", iata: "HA", icao: "HAL"),
+    AirlineInfo(name: "Allegiant Air", iata: "G4", icao: "AAY"),
+    AirlineInfo(name: "Air Canada", iata: "AC", icao: "ACA"),
+    AirlineInfo(name: "WestJet", iata: "WS", icao: "WJA"),
+    AirlineInfo(name: "Porter Airlines", iata: "PD", icao: "POE"),
+    
+    // Europe
+    AirlineInfo(name: "Lufthansa", iata: "LH", icao: "DLH"),
+    AirlineInfo(name: "British Airways", iata: "BA", icao: "BAW"),
+    AirlineInfo(name: "Air France", iata: "AF", icao: "AFR"),
+    AirlineInfo(name: "KLM Royal Dutch Airlines", iata: "KL", icao: "KLM"),
+    AirlineInfo(name: "Scandinavian Airlines", iata: "SK", icao: "SAS"),
+    AirlineInfo(name: "Iberia", iata: "IB", icao: "IBE"),
+    AirlineInfo(name: "Alitalia", iata: "AZ", icao: "AZA"),
+    AirlineInfo(name: "ITA Airways", iata: "AZ", icao: "ITY"),
+    AirlineInfo(name: "Swiss International Air Lines", iata: "LX", icao: "SWR"),
+    AirlineInfo(name: "Austrian Airlines", iata: "OS", icao: "AUA"),
+    AirlineInfo(name: "Brussels Airlines", iata: "SN", icao: "BEL"),
+    AirlineInfo(name: "Finnair", iata: "AY", icao: "FIN"),
+    AirlineInfo(name: "TAP Air Portugal", iata: "TP", icao: "TAP"),
+    AirlineInfo(name: "Ryanair", iata: "FR", icao: "RYR"),
+    AirlineInfo(name: "easyJet", iata: "U2", icao: "EZY"),
+    AirlineInfo(name: "Norwegian Air Shuttle", iata: "DY", icao: "NAX"),
+    AirlineInfo(name: "Wizz Air", iata: "W6", icao: "WZZ"),
+    AirlineInfo(name: "Eurowings", iata: "EW", icao: "EWG"),
+    AirlineInfo(name: "Vueling", iata: "VY", icao: "VLG"),
+    AirlineInfo(name: "Turkish Airlines", iata: "TK", icao: "THY"),
+    AirlineInfo(name: "Aer Lingus", iata: "EI", icao: "EIN"),
+    AirlineInfo(name: "LOT Polish Airlines", iata: "LO", icao: "LOT"),
+    AirlineInfo(name: "Czech Airlines", iata: "OK", icao: "CSA"),
+    AirlineInfo(name: "Air Europa", iata: "UX", icao: "AEA"),
+    AirlineInfo(name: "TUI fly", iata: "X3", icao: "TUI"),
+    AirlineInfo(name: "Condor", iata: "DE", icao: "CFG"),
+    
+    // Asia
+    AirlineInfo(name: "Emirates", iata: "EK", icao: "UAE"),
+    AirlineInfo(name: "Qatar Airways", iata: "QR", icao: "QTR"),
+    AirlineInfo(name: "Etihad Airways", iata: "EY", icao: "ETD"),
+    AirlineInfo(name: "Singapore Airlines", iata: "SQ", icao: "SIA"),
+    AirlineInfo(name: "Cathay Pacific", iata: "CX", icao: "CPA"),
+    AirlineInfo(name: "Japan Airlines", iata: "JL", icao: "JAL"),
+    AirlineInfo(name: "All Nippon Airways", iata: "NH", icao: "ANA"),
+    AirlineInfo(name: "Korean Air", iata: "KE", icao: "KAL"),
+    AirlineInfo(name: "Asiana Airlines", iata: "OZ", icao: "AAR"),
+    AirlineInfo(name: "China Southern Airlines", iata: "CZ", icao: "CSN"),
+    AirlineInfo(name: "China Eastern Airlines", iata: "MU", icao: "CES"),
+    AirlineInfo(name: "Air China", iata: "CA", icao: "CCA"),
+    AirlineInfo(name: "Thai Airways", iata: "TG", icao: "THA"),
+    AirlineInfo(name: "Malaysia Airlines", iata: "MH", icao: "MAS"),
+    AirlineInfo(name: "Philippine Airlines", iata: "PR", icao: "PAL"),
+    AirlineInfo(name: "Vietnam Airlines", iata: "VN", icao: "HVN"),
+    AirlineInfo(name: "Garuda Indonesia", iata: "GA", icao: "GIA"),
+    AirlineInfo(name: "IndiGo", iata: "6E", icao: "IGO"),
+    AirlineInfo(name: "Air India", iata: "AI", icao: "AIC"),
+    
+    // Middle East & Africa
+    AirlineInfo(name: "Royal Jordanian", iata: "RJ", icao: "RJA"),
+    AirlineInfo(name: "El Al", iata: "LY", icao: "ELY"),
+    AirlineInfo(name: "Ethiopian Airlines", iata: "ET", icao: "ETH"),
+    AirlineInfo(name: "South African Airways", iata: "SA", icao: "SAA"),
+    AirlineInfo(name: "EgyptAir", iata: "MS", icao: "MSR"),
+    AirlineInfo(name: "Kenya Airways", iata: "KQ", icao: "KQA"),
+    
+    // Oceania
+    AirlineInfo(name: "Qantas", iata: "QF", icao: "QFA"),
+    AirlineInfo(name: "Virgin Australia", iata: "VA", icao: "VOZ"),
+    AirlineInfo(name: "Jetstar Airways", iata: "JQ", icao: "JST"),
+    AirlineInfo(name: "Air New Zealand", iata: "NZ", icao: "ANZ"),
+    
+    // Latin America
+    AirlineInfo(name: "LATAM Airlines", iata: "LA", icao: "LAN"),
+    AirlineInfo(name: "Gol Linhas Aereas", iata: "G3", icao: "GLO"),
+    AirlineInfo(name: "Avianca", iata: "AV", icao: "AVA"),
+    AirlineInfo(name: "Copa Airlines", iata: "CM", icao: "CMP"),
+    AirlineInfo(name: "Aeromexico", iata: "AM", icao: "AMX"),
+    AirlineInfo(name: "Azul Brazilian Airlines", iata: "AD", icao: "AZU"),
+    
+    // Cargo
+    AirlineInfo(name: "FedEx Express", iata: "FX", icao: "FDX"),
+    AirlineInfo(name: "UPS Airlines", iata: "5X", icao: "UPS"),
+    AirlineInfo(name: "DHL Aviation", iata: "D0", icao: "DHK"),
+]

--- a/UpThere/Services/AviationStackConfig.swift
+++ b/UpThere/Services/AviationStackConfig.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Configuration for the AviationStack API
+/// Sign up at: https://aviationstack.com/
+struct AviationStackConfig {
+    /// AviationStack API access key
+    let apiKey: String?
+    
+    /// Base URL for the AviationStack API
+    let baseURL: String = "https://api.aviationstack.com/v1"
+    
+    /// Whether the API key is configured
+    var isConfigured: Bool {
+        guard let apiKey = apiKey, !apiKey.isEmpty else { return false }
+        return true
+    }
+    
+    /// Default configuration from environment variables
+    static let `default` = AviationStackConfig(
+        apiKey: ProcessInfo.processInfo.environment["AVIATIONSTACK_API_KEY"]
+    )
+    
+    /// Create a configuration with a specific API key
+    init(apiKey: String?) {
+        self.apiKey = apiKey
+    }
+}

--- a/UpThere/Services/FlightRouteService.swift
+++ b/UpThere/Services/FlightRouteService.swift
@@ -1,0 +1,145 @@
+import Foundation
+import os
+
+/// Service for fetching flight route information from AviationStack API
+actor FlightRouteService {
+    private let config: AviationStackConfig
+    private let session: URLSession
+    
+    /// In-memory cache for route info, keyed by ICAO24
+    private var cache: [String: FlightRouteInfo] = [:]
+    
+    /// Initializer for production use
+    nonisolated init(config: AviationStackConfig = .default) {
+        self.config = config
+        
+        let configuration = URLSessionConfiguration.default
+        configuration.timeoutIntervalForRequest = 15
+        configuration.timeoutIntervalForResource = 30
+        configuration.requestCachePolicy = .returnCacheDataElseLoad
+        self.session = URLSession(configuration: configuration)
+    }
+    
+    /// Initializer with custom URLSession (for testing)
+    nonisolated init(config: AviationStackConfig, session: URLSession) {
+        self.config = config
+        self.session = session
+    }
+    
+    /// Fetch route information for a flight
+    /// - Parameter flight: The flight to look up
+    /// - Returns: Route info if available, nil if not found or not configured
+    func fetchRoute(for flight: Flight) async throws -> FlightRouteInfo? {
+        // Check cache first
+        if let cached = cache[flight.id] {
+            AppLogger.flightService.debug("Route cache hit for \(flight.id, privacy: .public)")
+            return cached
+        }
+        
+        guard config.isConfigured else {
+            AppLogger.flightService.warning("AviationStack not configured, skipping route lookup")
+            return nil
+        }
+        
+        guard let callsign = flight.callsign.trimmingCharacters(in: .whitespaces).uppercased().nilIfEmpty else {
+            AppLogger.flightService.debug("No callsign for flight \(flight.id, privacy: .public), skipping route lookup")
+            return nil
+        }
+        
+        let url = try buildURL(for: callsign)
+        AppLogger.flightService.debug("Fetching route info: \(url.absoluteString, privacy: .public)")
+        
+        let request = URLRequest(url: url)
+        
+        do {
+            let (data, response) = try await session.data(for: request)
+            
+            guard let httpResponse = response as? HTTPURLResponse else {
+                AppLogger.flightService.error("Invalid response type from AviationStack API")
+                throw AviationStackError.invalidResponse
+            }
+            
+            switch httpResponse.statusCode {
+            case 200:
+                let routeInfo = try FlightRouteInfo.parse(from: data)
+                if let routeInfo = routeInfo {
+                    cache[flight.id] = routeInfo
+                    AppLogger.flightService.info("Fetched route info for \(flight.id, privacy: .public)")
+                } else {
+                    AppLogger.flightService.debug("No route data found for flight \(callsign, privacy: .public)")
+                }
+                return routeInfo
+            case 404:
+                AppLogger.flightService.debug("No route data found for flight \(callsign, privacy: .public)")
+                return nil
+            case 429:
+                AppLogger.flightService.warning("Rate limited by AviationStack API (429)")
+                throw AviationStackError.rateLimited
+            default:
+                if let errorText = String(data: data, encoding: .utf8), !errorText.isEmpty {
+                    AppLogger.flightService.error("AviationStack API error (\(httpResponse.statusCode, privacy: .public)): \(errorText, privacy: .public)")
+                }
+                throw AviationStackError.invalidResponse
+            }
+        } catch let error as AviationStackError {
+            throw error
+        } catch {
+            AppLogger.flightService.error("Network error fetching route info: \(error.localizedDescription, privacy: .public)")
+            throw AviationStackError.networkError(error)
+        }
+    }
+    
+    /// Clear the route cache
+    func clearCache() {
+        cache.removeAll()
+    }
+    
+    /// Build URL with query parameters for AviationStack flights endpoint
+    private func buildURL(for callsign: String) throws -> URL {
+        guard let apiKey = config.apiKey else {
+            throw AviationStackError.unauthorized
+        }
+        
+        var components = URLComponents(string: "\(config.baseURL)/flights")
+        components?.queryItems = [
+            URLQueryItem(name: "access_key", value: apiKey),
+            URLQueryItem(name: "flight_icao", value: callsign)
+        ]
+        
+        guard let url = components?.url else {
+            throw AviationStackError.invalidResponse
+        }
+        
+        return url
+    }
+}
+
+// MARK: - AviationStack Errors
+
+enum AviationStackError: Error, LocalizedError {
+    case invalidResponse
+    case networkError(Error)
+    case unauthorized
+    case rateLimited
+    
+    var errorDescription: String? {
+        switch self {
+        case .invalidResponse:
+            return "Invalid response from AviationStack API"
+        case .networkError(let error):
+            return "Network error: \(error.localizedDescription)"
+        case .unauthorized:
+            return "AviationStack API key not configured"
+        case .rateLimited:
+            return "AviationStack rate limit exceeded"
+        }
+    }
+}
+
+// MARK: - String helper
+
+private extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
+    }
+}

--- a/UpThere/ViewModels/UpThereViewModel.swift
+++ b/UpThere/ViewModels/UpThereViewModel.swift
@@ -23,9 +23,16 @@ class UpThereViewModel {
     /// Whether we're currently fetching historical data for the selected flight
     var isLoadingTrail = false
     
+    /// Route information for the selected flight (from AviationStack)
+    var selectedFlightRoute: FlightRouteInfo?
+    
+    /// Whether we're currently fetching route info for the selected flight
+    var isLoadingRoute = false
+    
     // MARK: - Services
     private let flightService: FlightService
     private let locationService: LocationService
+    private let routeService: FlightRouteService
     
     // MARK: - Configuration
     /// Search radius in kilometers (default 200km)
@@ -56,6 +63,7 @@ class UpThereViewModel {
     init() {
         self.flightService = FlightService()
         self.locationService = LocationService()
+        self.routeService = FlightRouteService()
     }
     
     // MARK: - Public Methods
@@ -77,6 +85,7 @@ class UpThereViewModel {
         locationService.stopUpdating()
         trails.removeAll()
         selectedFlightTrail = nil
+        selectedFlightRoute = nil
     }
     
     /// Manual refresh
@@ -198,19 +207,43 @@ class UpThereViewModel {
             // Tapping the same flight → deselect
             selectedFlight = nil
             selectedFlightTrail = nil
+            selectedFlightRoute = nil
             AppLogger.viewModel.debug("Deselected flight \(flight.id, privacy: .public)")
         } else if let flight = flight {
             // Selecting a new flight
             selectedFlight = flight
+            selectedFlightRoute = nil
             Task {
                 await fetchSelectedFlightTrail()
+                await fetchSelectedFlightRoute(flight: flight)
             }
             AppLogger.viewModel.debug("Selected flight \(flight.id, privacy: .public)")
         } else {
             // Deselecting (e.g., tapping empty space)
             selectedFlight = nil
             selectedFlightTrail = nil
+            selectedFlightRoute = nil
         }
+    }
+    
+    /// Fetch route information for the selected flight
+    private func fetchSelectedFlightRoute(flight: Flight) async {
+        isLoadingRoute = true
+        AppLogger.viewModel.debug("Fetching route info for \(flight.id, privacy: .public)")
+        
+        do {
+            selectedFlightRoute = try await routeService.fetchRoute(for: flight)
+            if selectedFlightRoute != nil {
+                AppLogger.viewModel.info("Route info fetched for \(flight.id, privacy: .public)")
+            } else {
+                AppLogger.viewModel.debug("No route data available for \(flight.id, privacy: .public)")
+            }
+        } catch {
+            AppLogger.viewModel.error("Failed to fetch route info: \(error.localizedDescription, privacy: .public)")
+            selectedFlightRoute = nil
+        }
+        
+        isLoadingRoute = false
     }
     
     /// Request location permission

--- a/UpThere/Views/FlightDetailView.swift
+++ b/UpThere/Views/FlightDetailView.swift
@@ -14,22 +14,7 @@ struct FlightDetailView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 20) {
                     // Header
-                    HStack {
-                        Spacer()
-                        VStack(spacing: 12) {
-                            Image(systemName: "airplane")
-                                .font(.system(size: 60))
-                                .foregroundColor(.orange)
-                                .rotationEffect(.degrees(flight.trueTrack ?? 0))
-                            
-                            Text(flight.formattedCallsign)
-                                .font(.title2)
-                                .fontWeight(.bold)
-                        }
-                        Spacer()
-                    }
-                    .padding()
-                    .background(Color.orange.opacity(0.1))
+                    headerView
                     
                     // Trail map
                     if let trail = viewModel.selectedFlightTrail, trail.isValid {
@@ -42,6 +27,11 @@ struct FlightDetailView: View {
                         }
                         .padding()
                     }
+                    
+                    // Route info section (NEW)
+                    routeSection
+                    
+                    Divider()
                     
                     // Info
                     Group {
@@ -127,6 +117,179 @@ struct FlightDetailView: View {
             }
         }
     }
+    
+    // MARK: - Header View
+    
+    private var headerView: some View {
+        HStack {
+            Spacer()
+            VStack(spacing: 12) {
+                HStack(spacing: 12) {
+                    // Airline logo (if available)
+                    if let logoURL = viewModel.selectedFlightRoute?.logoURL {
+                        AsyncImage(url: logoURL) { phase in
+                            switch phase {
+                            case .success(let image):
+                                image
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fit)
+                                    .frame(width: 40, height: 40)
+                            case .failure, .empty:
+                                airlineDesignatorBadge
+                            @unknown default:
+                                airlineDesignatorBadge
+                            }
+                        }
+                    } else {
+                        airlineDesignatorBadge
+                    }
+                    
+                    Image(systemName: "airplane")
+                        .font(.system(size: 60))
+                        .foregroundColor(.orange)
+                        .rotationEffect(.degrees(flight.trueTrack ?? 0))
+                }
+                
+                Text(flight.formattedCallsign)
+                    .font(.title2)
+                    .fontWeight(.bold)
+                
+                // Route display (e.g., "LAX → BOS")
+                if let route = viewModel.selectedFlightRoute?.formattedRoute {
+                    Text(route)
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+                
+                // Flight status badge
+                if let status = viewModel.selectedFlightRoute?.displayStatus {
+                    Text(status)
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 4)
+                        .background(statusColor.opacity(0.15))
+                        .foregroundColor(statusColor)
+                        .clipShape(Capsule())
+                }
+            }
+            Spacer()
+        }
+        .padding()
+        .background(Color.orange.opacity(0.1))
+    }
+    
+    /// Airline designator badge when logo is unavailable
+    private var airlineDesignatorBadge: some View {
+        Group {
+            if let designator = flight.airlineDesignator {
+                Text(designator)
+                    .font(.system(size: 16, weight: .bold, design: .monospaced))
+                    .foregroundColor(.orange)
+                    .frame(width: 40, height: 40)
+                    .background(Color.orange.opacity(0.15))
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+            } else {
+                Image(systemName: "airplane.circle.fill")
+                    .font(.system(size: 40))
+                    .foregroundColor(.orange.opacity(0.5))
+            }
+        }
+    }
+    
+    /// Status color based on route info
+    private var statusColor: Color {
+        guard let status = viewModel.selectedFlightRoute?.flightStatus?.lowercased() else { return .gray }
+        switch status {
+        case "active", "en-route", "en route":
+            return .green
+        case "landed":
+            return .blue
+        case "cancelled":
+            return .red
+        case "diverted":
+            return .orange
+        default:
+            return .gray
+        }
+    }
+    
+    // MARK: - Route Section
+    
+    @ViewBuilder
+    private var routeSection: some View {
+        if let route = viewModel.selectedFlightRoute, route.hasRouteData {
+            Group {
+                Text("Route").font(.headline)
+                
+                if let airline = route.formattedAirline {
+                    HStack {
+                        Text("Airline:")
+                        Spacer()
+                        Text(airline).fontWeight(.medium)
+                    }
+                }
+                
+                if let depAirport = route.departureAirportIata {
+                    HStack {
+                        Text("Origin:")
+                        Spacer()
+                        VStack(alignment: .trailing) {
+                            Text(depAirport).fontWeight(.medium)
+                            if let name = route.departureAirportName {
+                                Text(name)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                    }
+                }
+                
+                if let arrAirport = route.arrivalAirportIata {
+                    HStack {
+                        Text("Destination:")
+                        Spacer()
+                        VStack(alignment: .trailing) {
+                            Text(arrAirport).fontWeight(.medium)
+                            if let name = route.arrivalAirportName {
+                                Text(name)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                    }
+                }
+                
+                if let estimatedArrival = route.estimatedArrival {
+                    HStack {
+                        Text("Est. Arrival:")
+                        Spacer()
+                        Text(estimatedArrival, style: .time).fontWeight(.medium)
+                    }
+                } else if let scheduledArrival = route.scheduledArrival {
+                    HStack {
+                        Text("Scheduled Arrival:")
+                        Spacer()
+                        Text(scheduledArrival, style: .time).fontWeight(.medium)
+                    }
+                }
+            }
+            .padding(.horizontal)
+        } else if viewModel.isLoadingRoute {
+            Group {
+                Text("Route").font(.headline)
+                HStack {
+                    Spacer()
+                    ProgressView("Loading route info...")
+                    Spacer()
+                }
+            }
+            .padding(.horizontal)
+        }
+        // If no route data and not loading, we simply don't show the section
+    }
+    
+    // MARK: - Trail Map View
     
     @ViewBuilder
     private func trailMapView(trail: FlightTrail) -> some View {

--- a/UpThere/Views/FlightDetailView.swift
+++ b/UpThere/Views/FlightDetailView.swift
@@ -118,6 +118,38 @@ struct FlightDetailView: View {
         }
     }
     
+    // MARK: - Airline Info Helpers
+    
+    /// Airline info from local database (always available if callsign matches)
+    private var localAirlineInfo: AirlineInfo? {
+        guard let designator = flight.airlineDesignator else { return nil }
+        return AirlineDatabase.lookup(icao: designator)
+    }
+    
+    /// Logo URL — prefer API data, fall back to local database
+    private var logoURL: URL? {
+        // First try from API route data
+        if let url = viewModel.selectedFlightRoute?.logoURL {
+            return url
+        }
+        // Fall back to local database
+        if let info = localAirlineInfo {
+            return URL(string: "https://images.kiwi.com/airlines/64/\(info.iata).png")
+        }
+        return nil
+    }
+    
+    /// Airline display name — prefer API data, fall back to local database
+    private var airlineDisplayName: String? {
+        if let name = viewModel.selectedFlightRoute?.formattedAirline {
+            return name
+        }
+        if let info = localAirlineInfo {
+            return "\(info.name) (\(info.icao))"
+        }
+        return nil
+    }
+    
     // MARK: - Header View
     
     private var headerView: some View {
@@ -125,9 +157,9 @@ struct FlightDetailView: View {
             Spacer()
             VStack(spacing: 12) {
                 HStack(spacing: 12) {
-                    // Airline logo (if available)
-                    if let logoURL = viewModel.selectedFlightRoute?.logoURL {
-                        AsyncImage(url: logoURL) { phase in
+                    // Airline logo (from API or local database)
+                    if let url = logoURL {
+                        AsyncImage(url: url) { phase in
                             switch phase {
                             case .success(let image):
                                 image
@@ -218,11 +250,16 @@ struct FlightDetailView: View {
     
     @ViewBuilder
     private var routeSection: some View {
-        if let route = viewModel.selectedFlightRoute, route.hasRouteData {
+        let route = viewModel.selectedFlightRoute
+        let hasAirportData = route?.departureAirportIata != nil || route?.arrivalAirportIata != nil
+        let hasAirlineData = airlineDisplayName != nil
+        
+        if hasAirlineData || hasAirportData || viewModel.isLoadingRoute {
             Group {
                 Text("Route").font(.headline)
                 
-                if let airline = route.formattedAirline {
+                // Airline — from API or local database
+                if let airline = airlineDisplayName {
                     HStack {
                         Text("Airline:")
                         Spacer()
@@ -230,13 +267,14 @@ struct FlightDetailView: View {
                     }
                 }
                 
-                if let depAirport = route.departureAirportIata {
+                // Origin airport (from API)
+                if let depAirport = route?.departureAirportIata {
                     HStack {
                         Text("Origin:")
                         Spacer()
                         VStack(alignment: .trailing) {
                             Text(depAirport).fontWeight(.medium)
-                            if let name = route.departureAirportName {
+                            if let name = route?.departureAirportName {
                                 Text(name)
                                     .font(.caption)
                                     .foregroundColor(.secondary)
@@ -245,13 +283,14 @@ struct FlightDetailView: View {
                     }
                 }
                 
-                if let arrAirport = route.arrivalAirportIata {
+                // Destination airport (from API)
+                if let arrAirport = route?.arrivalAirportIata {
                     HStack {
                         Text("Destination:")
                         Spacer()
                         VStack(alignment: .trailing) {
                             Text(arrAirport).fontWeight(.medium)
-                            if let name = route.arrivalAirportName {
+                            if let name = route?.arrivalAirportName {
                                 Text(name)
                                     .font(.caption)
                                     .foregroundColor(.secondary)
@@ -260,33 +299,32 @@ struct FlightDetailView: View {
                     }
                 }
                 
-                if let estimatedArrival = route.estimatedArrival {
+                // Estimated/Scheduled arrival (from API)
+                if let estimatedArrival = route?.estimatedArrival {
                     HStack {
                         Text("Est. Arrival:")
                         Spacer()
                         Text(estimatedArrival, style: .time).fontWeight(.medium)
                     }
-                } else if let scheduledArrival = route.scheduledArrival {
+                } else if let scheduledArrival = route?.scheduledArrival {
                     HStack {
                         Text("Scheduled Arrival:")
                         Spacer()
                         Text(scheduledArrival, style: .time).fontWeight(.medium)
                     }
                 }
-            }
-            .padding(.horizontal)
-        } else if viewModel.isLoadingRoute {
-            Group {
-                Text("Route").font(.headline)
-                HStack {
-                    Spacer()
-                    ProgressView("Loading route info...")
-                    Spacer()
+                
+                // Loading indicator for route data
+                if viewModel.isLoadingRoute && route == nil {
+                    HStack {
+                        Spacer()
+                        ProgressView("Loading route info...")
+                        Spacer()
+                    }
                 }
             }
             .padding(.horizontal)
         }
-        // If no route data and not loading, we simply don't show the section
     }
     
     // MARK: - Trail Map View

--- a/UpThereTests/AirlineDatabaseTests.swift
+++ b/UpThereTests/AirlineDatabaseTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import Testing
+
+@testable import UpThere
+
+struct AirlineDatabaseTests {
+    
+    // MARK: - ICAO Lookup Tests
+    
+    @Test
+    func testLookupByIcaoKnownAirline() {
+        let info = AirlineDatabase.lookup(icao: "UAL")
+        
+        #expect(info != nil)
+        #expect(info?.name == "United Airlines")
+        #expect(info?.iata == "UA")
+        #expect(info?.icao == "UAL")
+    }
+    
+    @Test
+    func testLookupByIcaoScandinavianAirlines() {
+        let info = AirlineDatabase.lookup(icao: "SAS")
+        
+        #expect(info != nil)
+        #expect(info?.name == "Scandinavian Airlines")
+        #expect(info?.iata == "SK")
+        #expect(info?.icao == "SAS")
+    }
+    
+    @Test
+    func testLookupByIcaoCaseInsensitive() {
+        let info = AirlineDatabase.lookup(icao: "ual")
+        
+        #expect(info != nil)
+        #expect(info?.name == "United Airlines")
+    }
+    
+    @Test
+    func testLookupByIcaoUnknown() {
+        let info = AirlineDatabase.lookup(icao: "XXX")
+        
+        #expect(info == nil)
+    }
+    
+    // MARK: - IATA Lookup Tests
+    
+    @Test
+    func testLookupByIataKnownAirline() {
+        let info = AirlineDatabase.lookupIata("UA")
+        
+        #expect(info != nil)
+        #expect(info?.name == "United Airlines")
+        #expect(info?.iata == "UA")
+        #expect(info?.icao == "UAL")
+    }
+    
+    @Test
+    func testLookupByIataScandinavianAirlines() {
+        let info = AirlineDatabase.lookupIata("SK")
+        
+        #expect(info != nil)
+        #expect(info?.name == "Scandinavian Airlines")
+    }
+    
+    @Test
+    func testLookupByIataCaseInsensitive() {
+        let info = AirlineDatabase.lookupIata("ua")
+        
+        #expect(info != nil)
+        #expect(info?.name == "United Airlines")
+    }
+    
+    @Test
+    func testLookupByIataUnknown() {
+        let info = AirlineDatabase.lookupIata("XX")
+        
+        #expect(info == nil)
+    }
+    
+    // MARK: - Coverage Tests
+    
+    @Test
+    func testMajorAirlinesPresent() {
+        // Verify key airlines are in the database
+        #expect(AirlineDatabase.lookup(icao: "AAL")?.name == "American Airlines")
+        #expect(AirlineDatabase.lookup(icao: "DAL")?.name == "Delta Air Lines")
+        #expect(AirlineDatabase.lookup(icao: "BAW")?.name == "British Airways")
+        #expect(AirlineDatabase.lookup(icao: "DLH")?.name == "Lufthansa")
+        #expect(AirlineDatabase.lookup(icao: "AFR")?.name == "Air France")
+        #expect(AirlineDatabase.lookup(icao: "KLM")?.name == "KLM Royal Dutch Airlines")
+        #expect(AirlineDatabase.lookup(icao: "UAE")?.name == "Emirates")
+        #expect(AirlineDatabase.lookup(icao: "QFA")?.name == "Qantas")
+        #expect(AirlineDatabase.lookup(icao: "RYR")?.name == "Ryanair")
+        #expect(AirlineDatabase.lookup(icao: "EZY")?.name == "easyJet")
+    }
+}

--- a/UpThereTests/FlightRouteInfoTests.swift
+++ b/UpThereTests/FlightRouteInfoTests.swift
@@ -1,0 +1,134 @@
+import Foundation
+import Testing
+
+@testable import UpThere
+
+struct FlightRouteInfoTests {
+    
+    // MARK: - Parsing Tests
+    
+    @Test
+    func testParseValidRouteResponse() throws {
+        let routeInfo = try FlightRouteInfo.parse(from: RouteTestData.validRouteResponse)
+        
+        #expect(routeInfo != nil)
+        #expect(routeInfo?.airlineName == "United Airlines")
+        #expect(routeInfo?.airlineIata == "UA")
+        #expect(routeInfo?.airlineIcao == "UAL")
+        #expect(routeInfo?.departureAirportIata == "LAX")
+        #expect(routeInfo?.departureAirportIcao == "KLAX")
+        #expect(routeInfo?.departureAirportName == "Los Angeles International")
+        #expect(routeInfo?.arrivalAirportIata == "BOS")
+        #expect(routeInfo?.arrivalAirportIcao == "KBOS")
+        #expect(routeInfo?.arrivalAirportName == "Logan International")
+        #expect(routeInfo?.flightStatus == "active")
+    }
+    
+    @Test
+    func testParsePartialRouteResponse() throws {
+        let routeInfo = try FlightRouteInfo.parse(from: RouteTestData.partialRouteResponse)
+        
+        #expect(routeInfo != nil)
+        #expect(routeInfo?.airlineName == nil)
+        #expect(routeInfo?.airlineIata == nil)
+        #expect(routeInfo?.airlineIcao == nil)
+        #expect(routeInfo?.departureAirportIata == "FRA")
+        #expect(routeInfo?.arrivalAirportIata == "JFK")
+        #expect(routeInfo?.flightStatus == "landed")
+    }
+    
+    @Test
+    func testParseNoDataResponse() throws {
+        let routeInfo = try FlightRouteInfo.parse(from: RouteTestData.noDataResponse)
+        
+        #expect(routeInfo == nil)
+    }
+    
+    @Test
+    func testParseInvalidJSON() throws {
+        #expect(throws: Error.self) {
+            try FlightRouteInfo.parse(from: RouteTestData.invalidJSON)
+        }
+    }
+    
+    @Test
+    func testParseMissingDataKey() throws {
+        let routeInfo = try FlightRouteInfo.parse(from: RouteTestData.missingDataKey)
+        
+        #expect(routeInfo == nil)
+    }
+    
+    // MARK: - Computed Properties Tests
+    
+    @Test
+    func testLogoURLWithValidIata() throws {
+        let routeInfo = try FlightRouteInfo.parse(from: RouteTestData.validRouteResponse)!
+        
+        #expect(routeInfo.logoURL != nil)
+        #expect(routeInfo.logoURL?.absoluteString == "https://images.kiwi.com/airlines/64/UA.png")
+    }
+    
+    @Test
+    func testLogoURLWithNoIata() throws {
+        let routeInfo = try FlightRouteInfo.parse(from: RouteTestData.partialRouteResponse)!
+        
+        #expect(routeInfo.logoURL == nil)
+    }
+    
+    @Test
+    func testFormattedRoute() throws {
+        let routeInfo = try FlightRouteInfo.parse(from: RouteTestData.validRouteResponse)!
+        
+        #expect(routeInfo.formattedRoute == "LAX → BOS")
+    }
+    
+    @Test
+    func testFormattedRouteWithNoData() throws {
+        let routeInfo = try FlightRouteInfo.parse(from: RouteTestData.partialRouteResponse)!
+        
+        #expect(routeInfo.formattedRoute == "FRA → JFK")
+    }
+    
+    @Test
+    func testFormattedAirline() throws {
+        let routeInfo = try FlightRouteInfo.parse(from: RouteTestData.validRouteResponse)!
+        
+        #expect(routeInfo.formattedAirline == "United Airlines (UAL)")
+    }
+    
+    @Test
+    func testFormattedAirlineWithNoData() throws {
+        let routeInfo = try FlightRouteInfo.parse(from: RouteTestData.partialRouteResponse)!
+        
+        #expect(routeInfo.formattedAirline == nil)
+    }
+    
+    @Test
+    func testHasRouteData() throws {
+        let fullRoute = try FlightRouteInfo.parse(from: RouteTestData.validRouteResponse)!
+        #expect(fullRoute.hasRouteData == true)
+        
+        let partialRoute = try FlightRouteInfo.parse(from: RouteTestData.partialRouteResponse)!
+        #expect(partialRoute.hasRouteData == true)
+    }
+    
+    // MARK: - Display Helpers Tests
+    
+    @Test
+    func testDisplayStatus() throws {
+        let activeRoute = try FlightRouteInfo.parse(from: RouteTestData.validRouteResponse)!
+        #expect(activeRoute.displayStatus == "En Route")
+        
+        let landedRoute = try FlightRouteInfo.parse(from: RouteTestData.partialRouteResponse)!
+        #expect(landedRoute.displayStatus == "Landed")
+    }
+    
+    @Test
+    func testStatusColor() throws {
+        let activeRoute = try FlightRouteInfo.parse(from: RouteTestData.validRouteResponse)!
+        #expect(activeRoute.statusColor == "green")
+        
+        let landedRoute = try FlightRouteInfo.parse(from: RouteTestData.partialRouteResponse)!
+        #expect(landedRoute.statusColor == "blue")
+    }
+}

--- a/UpThereTests/FlightTests.swift
+++ b/UpThereTests/FlightTests.swift
@@ -165,6 +165,40 @@ struct FlightTests {
         #expect(flight.coordinate == nil)
     }
     
+    // MARK: - Airline Designator Tests
+    
+    @Test
+    func testAirlineDesignatorFromValidCallsign() {
+        let state = createValidState(callsign: "UAL1234")
+        let flight = Flight(from: state, lastUpdate: Date())!
+        
+        #expect(flight.airlineDesignator == "UAL")
+    }
+    
+    @Test
+    func testAirlineDesignatorFromCallsignWithSpaces() {
+        let state = createValidState(callsign: "  dal567  ")
+        let flight = Flight(from: state, lastUpdate: Date())!
+        
+        #expect(flight.airlineDesignator == "DAL")
+    }
+    
+    @Test
+    func testAirlineDesignatorReturnsNilForShortCallsign() {
+        let state = createValidState(callsign: "AB")
+        let flight = Flight(from: state, lastUpdate: Date())!
+        
+        #expect(flight.airlineDesignator == nil)
+    }
+    
+    @Test
+    func testAirlineDesignatorReturnsNilForNumericCallsign() {
+        let state = createValidState(callsign: "123456")
+        let flight = Flight(from: state, lastUpdate: Date())!
+        
+        #expect(flight.airlineDesignator == nil)
+    }
+    
     // MARK: - Helper
     
     private func createValidState(

--- a/UpThereTests/TestHelpers/RouteTestData.swift
+++ b/UpThereTests/TestHelpers/RouteTestData.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+/// Test data for AviationStack API responses
+enum RouteTestData {
+    
+    // MARK: - Valid API Responses
+    
+    /// Valid response with complete route data
+    static let validRouteResponse = """
+    {
+        "data": [{
+            "flight_date": "2026-04-04",
+            "flight_status": "active",
+            "departure": {
+                "airport": "Los Angeles International",
+                "timezone": "America/Los_Angeles",
+                "iata": "LAX",
+                "icao": "KLAX",
+                "scheduled": "2026-04-04T14:30:00+00:00",
+                "estimated": "2026-04-04T14:35:00+00:00"
+            },
+            "arrival": {
+                "airport": "Logan International",
+                "timezone": "America/New_York",
+                "iata": "BOS",
+                "icao": "KBOS",
+                "scheduled": "2026-04-04T22:54:00+00:00",
+                "estimated": "2026-04-04T23:00:00+00:00"
+            },
+            "airline": {
+                "name": "United Airlines",
+                "iata": "UA",
+                "icao": "UAL"
+            },
+            "flight": {
+                "number": "1234",
+                "iata": "UA1234",
+                "icao": "UAL1234"
+            }
+        }]
+    }
+    """.data(using: .utf8)!
+    
+    /// Valid response with partial route data (no airline)
+    static let partialRouteResponse = """
+    {
+        "data": [{
+            "flight_date": "2026-04-04",
+            "flight_status": "landed",
+            "departure": {
+                "airport": "Frankfurt Airport",
+                "timezone": "Europe/Berlin",
+                "iata": "FRA",
+                "icao": "EDDF",
+                "scheduled": "2026-04-04T08:00:00+00:00"
+            },
+            "arrival": {
+                "airport": "John F. Kennedy International",
+                "timezone": "America/New_York",
+                "iata": "JFK",
+                "icao": "KJFK",
+                "scheduled": "2026-04-04T11:30:00+00:00"
+            },
+            "airline": {
+                "name": null,
+                "iata": null,
+                "icao": null
+            },
+            "flight": {
+                "number": "999",
+                "iata": null,
+                "icao": "DLH999"
+            }
+        }]
+    }
+    """.data(using: .utf8)!
+    
+    /// Valid response with no data (flight not found)
+    static let noDataResponse = """
+    {
+        "data": []
+    }
+    """.data(using: .utf8)!
+    
+    // MARK: - Invalid Responses
+    
+    /// Invalid JSON
+    static let invalidJSON = "not valid json".data(using: .utf8)!
+    
+    /// Valid JSON but missing data key
+    static let missingDataKey = """
+    {
+        "pagination": {}
+    }
+    """.data(using: .utf8)!
+}


### PR DESCRIPTION
## Summary

- **Airline branding**: Displays airline name and logo in the flight detail view header, with fallback to ICAO designator badge when logo is unavailable
- **Route information**: New "Route" section shows origin/destination airports (IATA + full name) and estimated/scheduled arrival time
- **Flight status badge**: Color-coded status indicator (En Route, Landed, Cancelled, etc.)
- **AviationStack integration**: New service layer with in-memory caching and graceful degradation when API is not configured

## Implementation Details

### New Files
- `UpThere/Models/FlightRouteInfo.swift` — Route data model with AviationStack parsing and display helpers
- `UpThere/Services/AviationStackConfig.swift` — API key configuration via `AVIATIONSTACK_API_KEY` env var
- `UpThere/Services/FlightRouteService.swift` — Actor-based service with caching for route lookups
- `UpThereTests/FlightRouteInfoTests.swift` — 16 tests for parsing and display logic
- `UpThereTests/TestHelpers/RouteTestData.swift` — Test fixtures for AviationStack responses

### Modified Files
- `UpThere/Models/Flight.swift` — Added `airlineDesignator` computed property
- `UpThere/ViewModels/UpThereViewModel.swift` — Added route fetching on flight selection
- `UpThere/Views/FlightDetailView.swift` — Redesigned header with logo, added Route section
- `UpThereTests/FlightTests.swift` — Added airline designator tests
- `Requirements/ui/UIREQ-003-flight-detail-view.md` — Updated with new scenarios and layout

## Testing

- All 100 tests pass on both iOS and macOS targets
- New tests cover: route parsing (valid, partial, empty, invalid), logo URL computation, formatted display strings, airline designator extraction

## Configuration

Set `AVIATIONSTACK_API_KEY` environment variable to enable route lookups. Without it, the route section is gracefully hidden.

Closes #10